### PR TITLE
Update Maven Central URL to use https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <repository>
             <id>central</id>
             <name>Main Apache Maven Repository</name>
-            <url>http://repo.maven.apache.org/maven2/</url>
+            <url>https://repo.maven.apache.org/maven2/</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>


### PR DESCRIPTION
Update Maven Central URL to use https (see https://links.sonatype.com/central/501-https-required)