### PR TITLE
[WFCORE-6437] Release wildfly-legacy-test based on WF29

### DIFF
--- a/core/23.0.0/pom.xml
+++ b/core/23.0.0/pom.xml
@@ -23,7 +23,7 @@
    <parent>
       <groupId>org.wildfly.legacy.test</groupId>
       <artifactId>wildfly-legacy-core-parent</artifactId>
-      <version>7.0.1.Final-SNAPSHOT</version>
+      <version>8.0.0.Final-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/core/25.0.0/pom.xml
+++ b/core/25.0.0/pom.xml
@@ -34,7 +34,7 @@
    <packaging>jar</packaging>
 
    <properties>
-      <property.old.wildfly-core>17.0.0.Final</property.old.wildfly-core>
+      <property.old.wildfly-core>17.0.1.Final</property.old.wildfly-core>
    </properties>
 
    <dependencies>

--- a/core/25.0.0/pom.xml
+++ b/core/25.0.0/pom.xml
@@ -23,7 +23,7 @@
    <parent>
       <groupId>org.wildfly.legacy.test</groupId>
       <artifactId>wildfly-legacy-core-parent</artifactId>
-      <version>7.0.1.Final-SNAPSHOT</version>
+      <version>8.0.0.Final-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/core/29.0.0/pom.xml
+++ b/core/29.0.0/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.wildfly.legacy.test</groupId>
+      <artifactId>wildfly-legacy-core-parent</artifactId>
+      <version>7.0.1.Final-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
+   </parent>
+
+   <artifactId>wildfly-legacy-core-29_0_0</artifactId>
+
+   <name>WildFly: Legacy Test 21.1.x Core Controller</name>
+   <description>The legacy Test SPI 21.1.x core controller used by WildFly 29_0_0.Final</description>
+   <packaging>jar</packaging>
+
+   <properties>
+      <property.old.wildfly-core>22.0.0.Beta1-SNAPSHOT</property.old.wildfly-core>
+   </properties>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.wildfly.legacy.test</groupId>
+         <artifactId>wildfly-legacy-spi-dependencies</artifactId>
+         <type>pom</type>
+         <scope>provided</scope>
+         <exclusions>
+            <exclusion>
+               <groupId>org.wildfly.legacy.test.direct</groupId>
+               <artifactId>wildfly-controller</artifactId>
+            </exclusion>
+            <exclusion>
+               <groupId>org.wildfly.legacy.test.direct</groupId>
+               <artifactId>wildfly-deployment-repository</artifactId>
+            </exclusion>
+            <exclusion>
+               <groupId>org.wildfly.legacy.test.direct</groupId>
+               <artifactId>wildfly-server</artifactId>
+            </exclusion>
+            <exclusion>
+               <groupId>org.wildfly.legacy.test.direct</groupId>
+               <artifactId>wildfly-subsystem-test-framework</artifactId>
+            </exclusion>
+         </exclusions>
+      </dependency>
+      <dependency>
+         <groupId>org.wildfly.legacy.test</groupId>
+         <artifactId>wildfly-legacy-spi</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.wildfly.core</groupId>
+         <artifactId>wildfly-controller</artifactId>
+         <version>${property.old.wildfly-core}</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.wildfly.core</groupId>
+         <artifactId>wildfly-host-controller</artifactId>
+         <version>${property.old.wildfly-core}</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.wildfly.core</groupId>
+         <artifactId>wildfly-server</artifactId>
+         <version>${property.old.wildfly-core}</version>
+         <scope>provided</scope>
+      </dependency>
+   </dependencies>
+</project>

--- a/core/29.0.0/pom.xml
+++ b/core/29.0.0/pom.xml
@@ -23,7 +23,7 @@
    <parent>
       <groupId>org.wildfly.legacy.test</groupId>
       <artifactId>wildfly-legacy-core-parent</artifactId>
-      <version>7.0.1.Final-SNAPSHOT</version>
+      <version>8.0.0.Final-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/core/29.0.0/src/main/java/org/wildfly/legacy/test/controller/core_29_0_0/TestModelControllerFactory29_0_0.java
+++ b/core/29.0.0/src/main/java/org/wildfly/legacy/test/controller/core_29_0_0/TestModelControllerFactory29_0_0.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.legacy.test.controller.core_29_0_0;
+
+import org.jboss.as.controller.CapabilityRegistry;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.core.model.test.ModelInitializer;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.model.test.ModelTestModelControllerService;
+import org.jboss.as.model.test.ModelTestOperationValidatorFilter;
+import org.jboss.as.model.test.StringConfigurationPersister;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.legacy.test.spi.core.TestModelControllerFactory;
+
+/**
+ *
+ * @author Tomaz Cerar
+ */
+public class TestModelControllerFactory29_0_0 implements TestModelControllerFactory {
+
+    @Override
+    public ModelTestModelControllerService create(ProcessType processType, RunningModeControl runningModeControl,
+            StringConfigurationPersister persister, ModelTestOperationValidatorFilter validateOpsFilter, TestModelType type,
+            ModelInitializer modelInitializer, ExtensionRegistry extensionRegistry) {
+        ControlledProcessState processState = new ControlledProcessState(true);
+        CapabilityRegistry capabilityRegistry = new CapabilityRegistry(type == TestModelType.STANDALONE);
+        return new TestModelControllerService29_0_0(processType, runningModeControl, persister, validateOpsFilter, type,
+                modelInitializer, new TestModelControllerService29_0_0.DelegatingResourceDefinition(type), processState,
+                extensionRegistry, capabilityRegistry);
+    }
+
+    @Override
+    public InjectedValue<ContentRepository> getContentRepositoryInjector(ModelTestModelControllerService service) {
+        return ((TestModelControllerService29_0_0)service).getContentRepositoryInjector();
+    }
+}

--- a/core/29.0.0/src/main/java/org/wildfly/legacy/test/controller/core_29_0_0/TestModelControllerService29_0_0.java
+++ b/core/29.0.0/src/main/java/org/wildfly/legacy/test/controller/core_29_0_0/TestModelControllerService29_0_0.java
@@ -1,0 +1,622 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.legacy.test.controller.core_29_0_0;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+
+import org.jboss.as.controller.BootErrorCollector;
+import org.jboss.as.controller.CapabilityRegistry;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ProxyController;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.audit.AuditLogger;
+import org.jboss.as.controller.capability.registry.ImmutableCapabilityRegistry;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.persistence.ConfigurationFile;
+import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
+import org.jboss.as.controller.persistence.NullConfigurationPersister;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.services.path.PathManagerService;
+import org.jboss.as.controller.transform.Transformers;
+import org.jboss.as.core.model.test.ModelInitializer;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.domain.controller.DomainController;
+import org.jboss.as.domain.controller.LocalHostControllerInfo;
+import org.jboss.as.domain.controller.SlaveRegistrationException;
+import org.jboss.as.domain.controller.resources.DomainRootDefinition;
+import org.jboss.as.domain.management.CoreManagementResourceDefinition;
+import org.jboss.as.host.controller.HostControllerConfigurationPersister;
+import org.jboss.as.host.controller.HostControllerEnvironment;
+import org.jboss.as.host.controller.HostModelUtil;
+import org.jboss.as.host.controller.HostModelUtil.HostModelRegistrar;
+import org.jboss.as.host.controller.HostPathManagerService;
+import org.jboss.as.host.controller.HostRunningModeControl;
+import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
+import org.jboss.as.host.controller.mgmt.DomainHostExcludeRegistry;
+import org.jboss.as.host.controller.model.host.HostResourceDefinition;
+import org.jboss.as.host.controller.operations.LocalHostControllerInfoImpl;
+import org.jboss.as.model.test.ModelTestModelControllerService;
+import org.jboss.as.model.test.ModelTestOperationValidatorFilter;
+import org.jboss.as.model.test.StringConfigurationPersister;
+import org.jboss.as.protocol.mgmt.ManagementChannelHandler;
+import org.jboss.as.repository.ContentReference;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.as.repository.HostFileRepository;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.server.ServerEnvironment.LaunchType;
+import org.jboss.as.server.ServerEnvironmentResourceDescription;
+import org.jboss.as.server.ServerPathManagerService;
+import org.jboss.as.server.controller.resources.ServerRootResourceDefinition;
+import org.jboss.as.server.controller.resources.VersionModelInitializer;
+import org.jboss.as.version.ProductConfig;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.modules.Module;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ *
+ * @author Tomaz Cerar
+ */
+class TestModelControllerService29_0_0 extends ModelTestModelControllerService {
+
+    private final InjectedValue<ContentRepository> injectedContentRepository = new InjectedValue<>();
+    private final TestModelType type;
+    private final RunningModeControl runningModeControl;
+    private final PathManagerService pathManagerService;
+    private final ModelInitializer modelInitializer;
+    private final DelegatingResourceDefinition rootResourceDefinition;
+    private final ControlledProcessState processState;
+    private final ExtensionRegistry extensionRegistry;
+    private volatile Initializer initializer;
+    private final CapabilityRegistry capabilityRegistry;
+
+    TestModelControllerService29_0_0(ProcessType processType, RunningModeControl runningModeControl, StringConfigurationPersister persister, ModelTestOperationValidatorFilter validateOpsFilter,
+                                     TestModelType type, ModelInitializer modelInitializer, DelegatingResourceDefinition rootResourceDefinition, ControlledProcessState processState,
+                                     ExtensionRegistry extensionRegistry, CapabilityRegistry capabilityRegistry) {
+        super(processType, runningModeControl, null, persister, validateOpsFilter, rootResourceDefinition, processState, ExpressionResolver.TEST_RESOLVER, capabilityRegistry, Controller29x.INSTANCE);
+        this.type = type;
+        this.runningModeControl = runningModeControl;
+        this.capabilityRegistry = capabilityRegistry;
+        this.pathManagerService = type == TestModelType.STANDALONE ? new ServerPathManagerService(capabilityRegistry) : new HostPathManagerService(capabilityRegistry);
+        this.modelInitializer = modelInitializer;
+        this.rootResourceDefinition = rootResourceDefinition;
+        this.processState = processState;
+        this.extensionRegistry = extensionRegistry;
+
+        if (type == TestModelType.STANDALONE) {
+            initializer = new ServerInitializer();
+        } else if (type == TestModelType.HOST) {
+            //Remove the write-local-domain-controller operation since we already simulate that here
+            for (Iterator<ModelNode> it = persister.getBootOperations().iterator() ; it.hasNext() ; ) {
+                ModelNode op = it.next();
+                if (op.get(OP).asString().equals("write-local-domain-controller")) {
+                    System.out.println("WARNING: Test framework is removing the 'write-local-domain-controller' operation. If you are comparing xml results use a " +
+                             "ModelWriteSanitizer to add the \"domain-controller\" => {\"local\" => {}} part (See ShippedConfigurationsModelTestCase.testHostXml() for an example)");
+                    it.remove();
+                    break;
+                }
+            }
+            initializer = new HostInitializer();
+        } else if (type == TestModelType.DOMAIN) {
+            initializer = new DomainInitializer();
+        }
+    }
+
+    static TestModelControllerService29_0_0 create(ProcessType processType, RunningModeControl runningModeControl, StringConfigurationPersister persister, ModelTestOperationValidatorFilter validateOpsFilter,
+                                                   TestModelType type, ModelInitializer modelInitializer, ExtensionRegistry extensionRegistry) {
+        CapabilityRegistry capabilityRegistry = new CapabilityRegistry(type == TestModelType.STANDALONE);
+        return new TestModelControllerService29_0_0(processType, runningModeControl, persister, validateOpsFilter, type, modelInitializer, new DelegatingResourceDefinition(type), new ControlledProcessState(true), extensionRegistry, capabilityRegistry);
+    }
+
+    InjectedValue<ContentRepository> getContentRepositoryInjector(){
+        return injectedContentRepository;
+    }
+
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        if (initializer != null) {
+            initializer.setRootResourceDefinitionDelegate();
+        }
+        super.start(context);
+    }
+
+    @Override
+    protected void initCoreModel(ManagementModel managementModel, Resource modelControllerResource) {
+        //super.initCoreModel(managementModel, modelControllerResource);
+        Resource rootResource = managementModel.getRootResource();
+        ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
+
+        initializer.initCoreModel(rootResource, rootRegistration, modelControllerResource);
+        if (modelInitializer != null) {
+            modelInitializer.populateModel(managementModel);
+        }
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        super.stop(context);
+    }
+
+    private ServerEnvironment createStandaloneServerEnvironment() {
+        Properties props = new Properties();
+        File home = new File("target/jbossas");
+        delete(home);
+        home.mkdir();
+        delay(10);
+        props.put(ServerEnvironment.HOME_DIR, home.getAbsolutePath());
+
+        File standalone = new File(home, "standalone");
+        standalone.mkdir();
+        props.put(ServerEnvironment.SERVER_BASE_DIR, standalone.getAbsolutePath());
+
+        File configuration = new File(standalone, "configuration");
+        configuration.mkdir();
+        props.put(ServerEnvironment.SERVER_CONFIG_DIR, configuration.getAbsolutePath());
+
+        File xml = new File(configuration, "standalone.xml");
+        try {
+            xml.createNewFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        props.put(ServerEnvironment.JBOSS_SERVER_DEFAULT_CONFIG, "standalone.xml");
+
+        return new ServerEnvironment(null, props, new HashMap<>(), "standalone.xml", null,
+                LaunchType.STANDALONE, runningModeControl.getRunningMode(), null, false);
+    }
+
+    private HostControllerEnvironment createHostControllerEnvironment() {
+        try {
+            Map<String, String> props = new HashMap<String, String>();
+            File home = new File("target/jbossas");
+            delete(home);
+            home.mkdir();
+            int sleep = 10;
+            delay(sleep);
+            props.put(HostControllerEnvironment.HOME_DIR, home.getAbsolutePath());
+
+            File domain = new File(home, "domain");
+            domain.mkdir();
+            delay(sleep);
+            props.put(HostControllerEnvironment.DOMAIN_BASE_DIR, domain.getAbsolutePath());
+
+            File configuration = new File(domain, "configuration");
+            configuration.mkdir();
+            delay(sleep);
+            props.put(HostControllerEnvironment.DOMAIN_CONFIG_DIR, configuration.getAbsolutePath());
+
+
+            boolean isRestart = false;
+            String modulePath = "";
+            InetAddress processControllerAddress = InetAddress.getLocalHost();
+            Integer processControllerPort = 9999;
+            InetAddress hostControllerAddress = InetAddress.getLocalHost();
+            Integer hostControllerPort = 1234;
+            String defaultJVM = null;
+            String domainConfig = null;
+            String initialDomainConfig = null;
+            String hostConfig = null;
+            String initialHostConfig = null;
+            RunningMode initialRunningMode = runningModeControl.getRunningMode();
+            boolean backupDomainFiles = false;
+            boolean useCachedDc = false;
+            ProductConfig productConfig = ProductConfig.fromFilesystemSlot(Module.getBootModuleLoader(), WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.HOME_DIR, null), props);
+            return new HostControllerEnvironment(props, isRestart, modulePath, processControllerAddress, processControllerPort,
+                    hostControllerAddress, hostControllerPort, defaultJVM, domainConfig, initialDomainConfig, hostConfig, initialHostConfig,
+                    initialRunningMode, backupDomainFiles, useCachedDc, productConfig);
+        } catch (UnknownHostException e) {
+            // AutoGenerated
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void delay(int sleep) {
+        try {
+            Thread.sleep(sleep);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private LocalHostControllerInfoImpl createLocalHostControllerInfo(HostControllerEnvironment env) {
+        return new LocalHostControllerInfoImpl(null, env);
+    }
+
+    private HostFileRepository createHostFileRepository() {
+        return new HostFileRepository() {
+
+            @Override
+            public File[] getDeploymentFiles(ContentReference contentReference) {
+                return new File[0];
+            }
+
+            @Override
+            public File getDeploymentRoot(ContentReference contentReference) {
+                return null;
+            }
+
+            @Override
+            public void deleteDeployment(ContentReference contentReference) {
+
+            }
+
+            @Override
+            public File getFile(String relativePath) {
+                return null;
+            }
+
+            @Override
+            public File getConfigurationFile(String relativePath) {
+                return null;
+            }
+        };
+    }
+
+    private DomainController createDomainController(final HostControllerEnvironment env, final LocalHostControllerInfoImpl info) {
+        return new DomainController() {
+
+            @Override
+            public void unregisterRunningServer(String serverName) {
+            }
+
+            @Override
+            public void unregisterRemoteHost(final String id, Long remoteConnectionId, boolean cleanUnregistration){
+
+            }
+
+            @Override
+            public ImmutableCapabilityRegistry getCapabilityRegistry() {
+                return null;
+            }
+
+            @Override
+            public void stopLocalHost(int exitCode) {
+            }
+
+            @Override
+            public void stopLocalHost() {
+            }
+
+            @Override
+            public void registerRunningServer(ProxyController serverControllerClient) {
+            }
+
+
+            @Override
+            public void pingRemoteHost(String hostName) {
+            }
+
+            @Override
+            public boolean isHostRegistered(String id) {
+                return false;
+            }
+
+            @Override
+            public HostFileRepository getRemoteFileRepository() {
+                return null;
+            }
+
+            @Override
+            public ModelNode getProfileOperations(String profileName) {
+                return null;
+            }
+
+            @Override
+            public LocalHostControllerInfo getLocalHostInfo() {
+                return info;
+            }
+
+            @Override
+            public HostFileRepository getLocalFileRepository() {
+                return null;
+            }
+
+            @Override
+            public ExtensionRegistry getExtensionRegistry() {
+                return null;
+            }
+
+            @Override
+            public RunningMode getCurrentRunningMode() {
+                return null;
+            }
+
+            @Override
+            public ExpressionResolver getExpressionResolver() {
+                return null;
+            }
+
+            @Override
+            public void initializeMasterDomainRegistry(ManagementResourceRegistration root,
+                    ExtensibleConfigurationPersister configurationPersister, ContentRepository contentRepository,
+                    HostFileRepository fileRepository, ExtensionRegistry extensionRegistry, PathManagerService pathManager) {
+            }
+
+            @Override
+            public void initializeSlaveDomainRegistry(ManagementResourceRegistration root,
+                    ExtensibleConfigurationPersister configurationPersister, ContentRepository contentRepository,
+                    HostFileRepository fileRepository, LocalHostControllerInfo hostControllerInfo,
+                    ExtensionRegistry extensionRegistry, IgnoredDomainResourceRegistry ignoredDomainResourceRegistry,
+                    PathManagerService pathManager) {
+            }
+
+            @Override
+            public void registerRemoteHost(String string, ManagementChannelHandler mch, Transformers t, Long l, boolean bln) throws SlaveRegistrationException {
+            }
+        };
+    }
+
+    private void delete(File file) {
+        if (file.isDirectory()) {
+            for (File child : file.listFiles()) {
+                delete(child);
+            }
+        }
+        file.delete();
+    }
+
+    private interface Initializer {
+        void setRootResourceDefinitionDelegate();
+        void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource);
+    }
+
+    private class ServerInitializer implements Initializer {
+        final ExtensibleConfigurationPersister persister = new NullConfigurationPersister();
+        final ServerEnvironment environment = createStandaloneServerEnvironment();
+        final boolean parallelBoot = false;
+
+        public void setRootResourceDefinitionDelegate() {
+            rootResourceDefinition.setDelegate(new ServerRootResourceDefinition(
+                    injectedContentRepository.getValue(),
+                    persister,
+                    environment,
+                    processState,
+                    runningModeControl,
+                    extensionRegistry,
+                    parallelBoot,
+                    pathManagerService,
+                    null,
+                    authorizer,
+                    null,
+                    AuditLogger.NO_OP_LOGGER,
+                    getMutableRootResourceRegistrationProvider(),
+                    BOOT_ERROR_COLLECTOR,
+                    capabilityRegistry));
+        }
+
+        @Override
+        public void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
+            VersionModelInitializer.registerRootResource(rootResource, null);
+            Resource managementResource = Resource.Factory.create();
+            rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT), managementResource);
+            rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.SERVICE_CONTAINER), Resource.Factory.create());
+            rootResource.registerChild(ServerEnvironmentResourceDescription.RESOURCE_PATH, Resource.Factory.create());
+            pathManagerService.addPathManagerResources(rootResource);
+        }
+    }
+
+    private class HostInitializer implements Initializer {
+        final String hostName = "master";
+        final HostControllerEnvironment env = createHostControllerEnvironment();
+        final LocalHostControllerInfoImpl info = createLocalHostControllerInfo(env);
+        final IgnoredDomainResourceRegistry ignoredRegistry = new IgnoredDomainResourceRegistry(info);
+        final HostControllerConfigurationPersister persister = new HostControllerConfigurationPersister(env, info, Executors.newCachedThreadPool(), extensionRegistry, extensionRegistry);
+        final HostFileRepository hostFileRepository = createHostFileRepository();
+        final DomainController domainController = createDomainController(env, info);
+
+        @Override
+        public void setRootResourceDefinitionDelegate() {
+            rootResourceDefinition.setDelegate(
+                    new HostResourceDefinition(
+                            hostName,
+                            persister,
+                            env,
+                            (HostRunningModeControl)runningModeControl,
+                            hostFileRepository,
+                            info,
+                            null /*serverInventory*/,
+                            null /*remoteFileRepository*/,
+                            injectedContentRepository.getValue(),
+                            domainController,
+                            extensionRegistry,
+                            ignoredRegistry,
+                            processState,
+                            pathManagerService,
+                            authorizer,
+                            null,
+                            AuditLogger.NO_OP_LOGGER,
+                            BOOT_ERROR_COLLECTOR));
+        }
+
+        @Override
+        public void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
+            HostModelUtil.createRootRegistry(
+                    rootRegistration,
+                    env,
+                    ignoredRegistry,
+                    new HostModelRegistrar() {
+                        @Override
+                        public void registerHostModel(String hostName, ManagementResourceRegistration rootRegistration) {
+                        }
+                    },
+                    ProcessType.HOST_CONTROLLER,
+                    authorizer,
+                    modelControllerResource,
+                    new LocalHostControllerInfoImpl(processState, "host"),
+                    capabilityRegistry);
+
+            HostModelUtil.createHostRegistry(
+                    hostName,
+                    rootRegistration,
+                    persister,
+                    env,
+                    (HostRunningModeControl)runningModeControl,
+                    hostFileRepository,
+                    info,
+                    null /*serverInventory*/,
+                    null /*remoteFileRepository*/,
+                    injectedContentRepository.getValue(),
+                    domainController,
+                    extensionRegistry,
+                    extensionRegistry,
+                    ignoredRegistry,
+                    processState,
+                    pathManagerService,
+                    authorizer,
+                    null,
+                    AuditLogger.NO_OP_LOGGER,
+                    BOOT_ERROR_COLLECTOR);
+        }
+    }
+
+    private class DomainInitializer implements Initializer {
+
+        @Override
+        public void setRootResourceDefinitionDelegate() {
+        }
+
+        @Override
+        public void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
+            VersionModelInitializer.registerRootResource(rootResource, null);
+            final HostControllerEnvironment env = createHostControllerEnvironment();
+            final LocalHostControllerInfoImpl info = createLocalHostControllerInfo(env);
+            final IgnoredDomainResourceRegistry ignoredRegistry = new IgnoredDomainResourceRegistry(info);
+            final ExtensibleConfigurationPersister persister = new NullConfigurationPersister();
+            final HostFileRepository hostFileRepository = createHostFileRepository();
+            final DomainController domainController = createDomainController(env, info);
+            final DomainHostExcludeRegistry domainHostExcludeRegistry = new DomainHostExcludeRegistry();
+
+            DomainRootDefinition domainDefinition = new DomainRootDefinition(
+                    domainController,
+                    env,
+                    persister,
+                    injectedContentRepository.getValue(),
+                    hostFileRepository,
+                    true,
+                    info,
+                    extensionRegistry,
+                    null,
+                    pathManagerService,
+                    authorizer,
+                    null,
+                    null,
+                    domainHostExcludeRegistry,
+                    getMutableRootResourceRegistrationProvider());
+            domainDefinition.initialize(rootRegistration);
+            rootResourceDefinition.setDelegate(domainDefinition);
+
+            HostModelUtil.createRootRegistry(
+                    rootRegistration,
+                    env, ignoredRegistry,
+                    (hostName, root) -> {},
+                    processType,
+                    authorizer,
+                    modelControllerResource,
+                    new LocalHostControllerInfoImpl(processState, "host"),
+                    capabilityRegistry);
+            CoreManagementResourceDefinition.registerDomainResource(rootResource, null);
+        }
+
+    }
+
+    static class DelegatingResourceDefinition extends org.jboss.as.controller.DelegatingResourceDefinition {
+        private final TestModelType type;
+
+        public DelegatingResourceDefinition(TestModelType type) {
+            this.type = type;
+        }
+
+        @Override
+        public void setDelegate(ResourceDefinition delegate) {
+            super.setDelegate(delegate);
+        }
+
+        @Override
+        public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+            if (type == TestModelType.DOMAIN) {
+                return;
+            }
+            super.registerOperations(resourceRegistration);
+        }
+
+        @Override
+        public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+            if (type == TestModelType.DOMAIN) {
+                return;
+            }
+            super.registerChildren(resourceRegistration);
+        }
+
+        @Override
+        public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+            if (type == TestModelType.DOMAIN) {
+                return;
+            }
+            super.registerAttributes(resourceRegistration);
+        }
+
+        @Override
+        public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+            if (type == TestModelType.DOMAIN) {
+                return;
+            }
+            super.registerNotifications(resourceRegistration);
+        }
+
+        @Override
+        public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+            if (type == TestModelType.DOMAIN) {
+                return;
+            }
+            super.registerCapabilities(resourceRegistration);
+        }
+
+        @Override
+        public void registerAdditionalRuntimePackages(ManagementResourceRegistration resourceRegistration) {
+            if (type == TestModelType.DOMAIN) {
+                return;
+            }
+            super.registerAdditionalRuntimePackages(resourceRegistration);
+        }
+    }
+
+    private static BootErrorCollector BOOT_ERROR_COLLECTOR = new BootErrorCollector();
+}

--- a/core/29.0.0/src/main/java/org/wildfly/legacy/test/controller/core_29_0_0/TestModelControllerService29_0_0.java
+++ b/core/29.0.0/src/main/java/org/wildfly/legacy/test/controller/core_29_0_0/TestModelControllerService29_0_0.java
@@ -44,7 +44,6 @@ import org.jboss.as.controller.audit.AuditLogger;
 import org.jboss.as.controller.capability.registry.ImmutableCapabilityRegistry;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
-import org.jboss.as.controller.persistence.ConfigurationFile;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -83,11 +82,11 @@ import org.jboss.as.server.controller.resources.ServerRootResourceDefinition;
 import org.jboss.as.server.controller.resources.VersionModelInitializer;
 import org.jboss.as.version.ProductConfig;
 import org.jboss.dmr.ModelNode;
+import org.jboss.modules.Module;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.jboss.modules.Module;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**

--- a/core/29.0.0/src/main/resources/META-INF/services/org.wildfly.legacy.test.spi.core.TestModelControllerFactory
+++ b/core/29.0.0/src/main/resources/META-INF/services/org.wildfly.legacy.test.spi.core.TestModelControllerFactory
@@ -1,0 +1,19 @@
+#
+# JBoss, Home of Professional Open Source
+# Copyright 2020, Red Hat, Inc., and individual contributors as indicated
+# by the @authors tag.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.wildfly.legacy.test.controller.core_29_0_0.TestModelControllerFactory29_0_0

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,6 +35,7 @@
     <modules>
         <module>23.0.0</module>
         <module>25.0.0</module>
+        <module>29.0.0</module>
     </modules>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-test-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
       -->
 
       <!-- This is really the version of WildFly Core -->
-      <wildfly.current.version>18.0.0.Final</wildfly.current.version>
+      <wildfly.current.version>22.0.0.Beta1-SNAPSHOT</wildfly.current.version>
 
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>wildfly-legacy-test-parent</artifactId>
 
     <groupId>org.wildfly.legacy.test</groupId>
-    <version>7.0.1.Final-SNAPSHOT</version>
+    <version>8.0.0.Final-SNAPSHOT</version>
     <name>WildFly: Legacy Test</name>
     <packaging>pom</packaging>
 

--- a/spi/dependencies/pom.xml
+++ b/spi/dependencies/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-spi-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spi/interfaces/pom.xml
+++ b/spi/interfaces/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-spi-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-test-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/subsystem/23.0.0/pom.xml
+++ b/subsystem/23.0.0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-subsystem-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/subsystem/25.0.0/pom.xml
+++ b/subsystem/25.0.0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-subsystem-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/subsystem/25.0.0/pom.xml
+++ b/subsystem/25.0.0/pom.xml
@@ -34,7 +34,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <property.old.wildfly-core>17.0.0.Final</property.old.wildfly-core>
+        <property.old.wildfly-core>17.0.1.Final</property.old.wildfly-core>
     </properties>
 
     <dependencies>

--- a/subsystem/29.0.0/pom.xml
+++ b/subsystem/29.0.0/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2020, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.legacy.test</groupId>
+        <artifactId>wildfly-legacy-subsystem-parent</artifactId>
+        <version>7.0.1.Final-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>wildfly-legacy-subsystem-29.0.0</artifactId>
+
+    <name>WildFly: Legacy Test 29.0.0 Subsystem Controller</name>
+    <description>The legacy Test 29.0.0 subsystem controller</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <property.old.wildfly-core>22.0.0.Beta1-SNAPSHOT</property.old.wildfly-core>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.legacy.test</groupId>
+            <artifactId>wildfly-legacy-spi-dependencies</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wildfly.legacy.test.direct</groupId>
+                    <artifactId>wildfly-controller</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.wildfly.legacy.test.direct</groupId>
+                    <artifactId>wildfly-core-model-test-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.wildfly.legacy.test.direct</groupId>
+                    <artifactId>wildfly-deployment-repository</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.wildfly.legacy.test.direct</groupId>
+                    <artifactId>wildfly-server</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.legacy.test</groupId>
+            <artifactId>wildfly-legacy-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <version>${property.old.wildfly-core}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+            <version>${property.old.wildfly-core}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/subsystem/29.0.0/pom.xml
+++ b/subsystem/29.0.0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-subsystem-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/subsystem/29.0.0/src/main/java/org/jboss/as/subsystem/test/AdditionalInitializationUtil.java
+++ b/subsystem/29.0.0/src/main/java/org/jboss/as/subsystem/test/AdditionalInitializationUtil.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.subsystem.test;
+
+import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.subsystem.test.ControllerInitializer.TestControllerAccessor;
+import org.wildfly.legacy.test.controller.subsystem_29_0_0.TestModelControllerService29_0_0;
+
+/**
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class AdditionalInitializationUtil {
+
+    private AdditionalInitializationUtil() {
+    }
+
+    public static ProcessType getProcessType(AdditionalInitialization additionalInit) {
+        return additionalInit.getProcessType();
+    }
+
+    public static RunningMode getRunningMode(AdditionalInitialization additionalInit) {
+        return additionalInit.getRunningMode();
+    }
+
+
+    public static void doExtraInitialization(AdditionalInitialization additionalInit, ControllerInitializer controllerInitializer, ExtensionRegistry extensionRegistry, ManagementModel managementModel, TestModelControllerService29_0_0 controller) {
+        controllerInitializer.setTestModelControllerAccessor(new TestControllerAccessor29_0_0(controller));
+        controllerInitializer.initializeModel(managementModel.getRootResource(), managementModel.getRootResourceRegistration());
+        additionalInit.initializeExtraSubystemsAndModel(extensionRegistry, managementModel.getRootResource(), managementModel.getRootResourceRegistration(), managementModel.getCapabilityRegistry());
+    }
+
+    private static class TestControllerAccessor29_0_0 implements TestControllerAccessor {
+        private final TestModelControllerService29_0_0 delegate;
+
+        public TestControllerAccessor29_0_0(TestModelControllerService29_0_0 delegate) {
+            this.delegate = delegate;
+        }
+
+
+        @Override
+        public ServerEnvironment getServerEnvironment() {
+            return delegate.getServerEnvironment();
+        }
+
+    }
+}

--- a/subsystem/29.0.0/src/main/java/org/wildfly/legacy/test/controller/subsystem_29_0_0/TestModelControllerFactory29_0_0.java
+++ b/subsystem/29.0.0/src/main/java/org/wildfly/legacy/test/controller/subsystem_29_0_0/TestModelControllerFactory29_0_0.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.legacy.test.controller.subsystem_29_0_0;
+
+import org.jboss.as.controller.CapabilityRegistry;
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.model.test.ModelTestModelControllerService;
+import org.jboss.as.model.test.ModelTestOperationValidatorFilter;
+import org.jboss.as.model.test.StringConfigurationPersister;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.AdditionalInitializationUtil;
+import org.jboss.as.subsystem.test.ControllerInitializer;
+import org.wildfly.legacy.test.spi.subsystem.TestModelControllerFactory;
+
+/**
+ *
+ * @author Tomaz Cerar
+ */
+public class TestModelControllerFactory29_0_0 implements TestModelControllerFactory {
+
+    @Override
+    public ModelTestModelControllerService create(Extension mainExtension, ControllerInitializer controllerInitializer,
+            AdditionalInitialization additionalInit, ExtensionRegistry extensionRegistry, StringConfigurationPersister persister,
+            ModelTestOperationValidatorFilter validateOpsFilter, boolean registerTransformers) {
+        final ProcessType processType = AdditionalInitializationUtil.getProcessType(additionalInit);
+        final CapabilityRegistry capabilityRegistry = new CapabilityRegistry(processType.isServer());
+        return new TestModelControllerService29_0_0(
+                processType,
+                mainExtension,
+                controllerInitializer,
+                additionalInit,
+                new RunningModeControl(AdditionalInitializationUtil.getRunningMode(additionalInit)),
+                extensionRegistry,
+                persister,
+                validateOpsFilter,
+                registerTransformers,
+                capabilityRegistry
+        );
+    }
+}

--- a/subsystem/29.0.0/src/main/java/org/wildfly/legacy/test/controller/subsystem_29_0_0/TestModelControllerService29_0_0.java
+++ b/subsystem/29.0.0/src/main/java/org/wildfly/legacy/test/controller/subsystem_29_0_0/TestModelControllerService29_0_0.java
@@ -1,0 +1,193 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.legacy.test.controller.subsystem_29_0_0;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.jboss.as.controller.CapabilityRegistry;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.extension.ExtensionRegistryType;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.model.test.ModelTestModelControllerService;
+import org.jboss.as.model.test.ModelTestOperationValidatorFilter;
+import org.jboss.as.model.test.StringConfigurationPersister;
+import org.jboss.as.repository.ContentReference;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.as.server.DeployerChainAddHandler;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.server.ServerEnvironment.LaunchType;
+import org.jboss.as.server.controller.resources.ServerDeploymentResourceDefinition;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.AdditionalInitializationUtil;
+import org.jboss.as.subsystem.test.ControllerInitializer;
+import org.jboss.dmr.ModelNode;
+import org.jboss.vfs.VirtualFile;
+
+/**
+ * @author Tomaz Cerar
+ */
+public class TestModelControllerService29_0_0 extends ModelTestModelControllerService {
+    private final Extension mainExtension;
+    private final AdditionalInitialization additionalInit;
+    private final ControllerInitializer controllerInitializer;
+    private final ExtensionRegistry extensionRegistry;
+    private final RunningModeControl runningModeControl;
+    private final ContentRepository contentRepository = new MockContentRepository();
+    private final boolean registerTransformers;
+
+    TestModelControllerService29_0_0(final ProcessType processType, final Extension mainExtension, final ControllerInitializer controllerInitializer,
+                                     final AdditionalInitialization additionalInit, final RunningModeControl runningModeControl, final ExtensionRegistry extensionRegistry,
+                                     final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter, final boolean registerTransformers,
+                                     final CapabilityRegistry capabilityRegistry) {
+        super(processType, runningModeControl, extensionRegistry.getTransformerRegistry(), persister, validateOpsFilter,
+                new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()),
+                new ControlledProcessState(true), capabilityRegistry, Controller23x.INSTANCE);
+        this.mainExtension = mainExtension;
+        this.additionalInit = additionalInit;
+        this.controllerInitializer = controllerInitializer;
+        this.extensionRegistry = extensionRegistry;
+        this.runningModeControl = runningModeControl;
+        this.registerTransformers = registerTransformers;
+    }
+
+    @Override
+    protected void initExtraModel(ManagementModel managementModel) {
+        Resource rootResource = managementModel.getRootResource();
+        ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
+        rootResource.getModel().get(SUBSYSTEM);
+
+        ManagementResourceRegistration deployments = rootRegistration.registerSubModel(ServerDeploymentResourceDefinition.create(contentRepository, getServerEnvironment()));
+
+        //Hack to be able to access the registry for the jmx facade
+        //rootRegistration.registerOperationHandler(RootResourceHack.DEFINITION, RootResourceHack.INSTANCE);
+
+        //extensionRegistry.setSubsystemParentResourceRegistrations(rootRegistration, deployments);
+        AdditionalInitializationUtil.doExtraInitialization(additionalInit, controllerInitializer, extensionRegistry, managementModel, this);
+    }
+
+    @Override
+    protected void initModel(ManagementModel managementModel, Resource modelControllerResource) {
+        super.initModel(managementModel, modelControllerResource);
+    }
+
+    @Override
+    protected void initCoreModel(ManagementModel managementModel, Resource modelControllerResource) {
+        super.initCoreModel(managementModel, modelControllerResource);
+        // register the global notifications so there is no warning that emitted notifications are not described by the resource.
+        GlobalNotifications.registerGlobalNotifications(managementModel.getRootResourceRegistration(), processType);
+    }
+
+    @Override
+    protected void preBoot(List<ModelNode> bootOperations, boolean rollbackOnRuntimeFailure) {
+        mainExtension.initialize(extensionRegistry.getExtensionContext("Test", getRootRegistration(), ExtensionRegistryType.SERVER));
+    }
+
+
+    protected void postBoot() {
+        DeployerChainAddHandler.INSTANCE.clearDeployerMap();
+    }
+
+    private void delete(File file) {
+        if (file.isDirectory()) {
+            for (File child : file.listFiles()) {
+                delete(child);
+            }
+        }
+        file.delete();
+    }
+
+    public ServerEnvironment getServerEnvironment() {
+        Properties props = new Properties();
+        File home = new File("target/jbossas");
+        delete(home);
+        home.mkdir();
+        props.put(ServerEnvironment.HOME_DIR, home.getAbsolutePath());
+
+        File standalone = new File(home, "standalone");
+        standalone.mkdir();
+        props.put(ServerEnvironment.SERVER_BASE_DIR, standalone.getAbsolutePath());
+
+        File configuration = new File(standalone, "configuration");
+        configuration.mkdir();
+        props.put(ServerEnvironment.SERVER_CONFIG_DIR, configuration.getAbsolutePath());
+
+        File xml = new File(configuration, "standalone.xml");
+        try {
+            xml.createNewFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        props.put(ServerEnvironment.JBOSS_SERVER_DEFAULT_CONFIG, "standalone.xml");
+
+        return new ServerEnvironment(null, props, new HashMap<>(), "standalone.xml", null, LaunchType.STANDALONE, runningModeControl.getRunningMode(), null, false);
+    }
+
+    private static class MockContentRepository implements ContentRepository {
+
+        @Override
+        public byte[] addContent(InputStream stream) throws IOException {
+            return null;
+        }
+
+        @Override
+        public VirtualFile getContent(byte[] hash) {
+            return null;
+        }
+
+        @Override
+        public boolean hasContent(byte[] hash) {
+            return false;
+        }
+
+        @Override
+        public boolean syncContent(ContentReference reference) {
+            return false;
+        }
+
+        @Override
+        public void removeContent(ContentReference reference) {
+        }
+
+        @Override
+        public void addContentReference(ContentReference reference) {
+        }
+
+        @Override
+        public Map<String, Set<String>> cleanObsoleteContent() {
+            return null;
+        }
+    }
+}

--- a/subsystem/29.0.0/src/main/resources/META-INF/services/org.wildfly.legacy.test.spi.subsystem.TestModelControllerFactory
+++ b/subsystem/29.0.0/src/main/resources/META-INF/services/org.wildfly.legacy.test.spi.subsystem.TestModelControllerFactory
@@ -1,0 +1,19 @@
+#
+# JBoss, Home of Professional Open Source
+# Copyright 2020, Red Hat, Inc., and individual contributors as indicated
+# by the @authors tag.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.wildfly.legacy.test.controller.subsystem_29_0_0.TestModelControllerFactory29_0_0

--- a/subsystem/pom.xml
+++ b/subsystem/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-test-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/subsystem/pom.xml
+++ b/subsystem/pom.xml
@@ -37,6 +37,7 @@
     <modules>
         <module>23.0.0</module>
         <module>25.0.0</module>
+        <module>29.0.0</module>
     </modules>
 
 </project>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-test-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tools/src/main/resources/legacy-models/README.txt
+++ b/tools/src/main/resources/legacy-models/README.txt
@@ -1,1 +1,4 @@
 The files in this folder have the suffix -version.dmr, where version matches the EAP release these were created from.
+
+The exception is -wf29.dmr, which is what will become EAP 8.0.0. Once that version is out all files with the -wf29.dmr suffix should
+be renamed to -8.0.0.dmr.

--- a/tools/src/main/resources/legacy-models/domain-resource-definition-wf29dmr
+++ b/tools/src/main/resources/legacy-models/domain-resource-definition-wf29dmr
@@ -1,0 +1,6619 @@
+{
+    "description" => "The root node of the domain-level management model.",
+    "min-occurs" => 1,
+    "max-occurs" => 1,
+    "capabilities" => [
+        {
+            "name" => "org.wildfly.management.executor",
+            "dynamic" => false
+        },
+        {
+            "name" => "org.wildfly.management.model-controller-client-factory",
+            "dynamic" => false
+        },
+        {
+            "name" => "org.wildfly.management.expression-resolver-extension-registry",
+            "dynamic" => false
+        },
+        {
+            "name" => "org.wildfly.management.notification-handler-registry",
+            "dynamic" => false
+        },
+        {
+            "name" => "org.wildfly.management.console-availability",
+            "dynamic" => false
+        },
+        {
+            "name" => "org.wildfly.management.path-manager",
+            "dynamic" => false
+        },
+        {
+            "name" => "org.wildfly.management.process-state-notifier",
+            "dynamic" => false
+        }
+    ],
+    "attributes" => {
+        "domain-organization" => {
+            "type" => STRING,
+            "description" => "Identification of the current organization this domain is a part of.",
+            "expressions-allowed" => false,
+            "required" => false,
+            "nillable" => true,
+            "min-length" => 1L,
+            "max-length" => 2147483647L,
+            "access-type" => "read-write",
+            "storage" => "configuration",
+            "restart-required" => "no-services"
+        },
+        "launch-type" => {
+            "type" => STRING,
+            "description" => "The manner in which the server process was launched. Either \"DOMAIN\" for a domain mode server launched by a Host Controller, \"STANDALONE\" for a standalone server launched from the command line, or \"EMBEDDED\" for a standalone server launched as an embedded part of an application running in the same virtual machine.",
+            "expressions-allowed" => false,
+            "required" => true,
+            "nillable" => false,
+            "allowed" => [
+                "DOMAIN",
+                "STANDALONE",
+                "EMBEDDED",
+                "SELF_CONTAINED",
+                "APPCLIENT"
+            ],
+            "access-type" => "read-only",
+            "storage" => "runtime"
+        },
+        "local-host-name" => {
+            "type" => STRING,
+            "description" => "The name of the locally running host controller.",
+            "expressions-allowed" => false,
+            "required" => false,
+            "nillable" => true,
+            "min-length" => 1L,
+            "max-length" => 2147483647L,
+            "access-type" => "read-only",
+            "storage" => "runtime"
+        },
+        "management-major-version" => {
+            "type" => INT,
+            "description" => "The major version of the WildFly Core kernel management interface that is provided by the host controller that is acting as the domain controller.",
+            "expressions-allowed" => false,
+            "required" => true,
+            "nillable" => false,
+            "min" => 1L,
+            "max" => 2147483647L,
+            "access-type" => "read-only",
+            "storage" => "configuration"
+        },
+        "management-micro-version" => {
+            "type" => INT,
+            "description" => "The micro version of the WildFly Core kernel management interface that is provided by the host controller that is acting as the domain controller.",
+            "expressions-allowed" => false,
+            "required" => true,
+            "nillable" => false,
+            "min" => 0L,
+            "max" => 2147483647L,
+            "access-type" => "read-only",
+            "storage" => "configuration"
+        },
+        "management-minor-version" => {
+            "type" => INT,
+            "description" => "The minor version of the WildFly Core kernel management interface that is provided by the host controller that is acting as the domain controller.",
+            "expressions-allowed" => false,
+            "required" => true,
+            "nillable" => false,
+            "min" => 0L,
+            "max" => 2147483647L,
+            "access-type" => "read-only",
+            "storage" => "configuration"
+        },
+        "name" => {
+            "type" => STRING,
+            "description" => "The name given to this domain.",
+            "expressions-allowed" => false,
+            "required" => false,
+            "nillable" => true,
+            "default" => "Unnamed Domain",
+            "min-length" => 1L,
+            "max-length" => 2147483647L,
+            "access-constraints" => {"sensitive" => {"domain-names" => {"type" => "core"}}},
+            "access-type" => "read-write",
+            "storage" => "configuration",
+            "restart-required" => "no-services"
+        },
+        "namespaces" => {
+            "type" => OBJECT,
+            "description" => "Map of namespaces used in the configuration XML document, where keys are namespace prefixes and values are schema URIs.",
+            "expressions-allowed" => false,
+            "required" => true,
+            "nillable" => false,
+            "value-type" => STRING,
+            "access-type" => "read-only",
+            "storage" => "configuration"
+        },
+        "process-type" => {
+            "type" => STRING,
+            "description" => "The type of process represented by this root resource. Either \"Domain Controller\" or \"Host Controller\".",
+            "expressions-allowed" => false,
+            "required" => true,
+            "nillable" => false,
+            "min-length" => 1L,
+            "max-length" => 2147483647L,
+            "access-type" => "read-only",
+            "storage" => "runtime"
+        },
+        "product-name" => {
+            "type" => STRING,
+            "description" => "The name of the WildFly Core based product that is being run by the host controller that is acting as the domain controller.",
+            "expressions-allowed" => false,
+            "required" => false,
+            "nillable" => true,
+            "min-length" => 1L,
+            "max-length" => 2147483647L,
+            "access-type" => "read-only",
+            "storage" => "configuration"
+        },
+        "product-version" => {
+            "type" => STRING,
+            "description" => "The version of the WildFly Core based product release that is being run by the host controller that is acting as the domain controller.",
+            "expressions-allowed" => false,
+            "required" => false,
+            "nillable" => true,
+            "min-length" => 1L,
+            "max-length" => 2147483647L,
+            "access-type" => "read-only",
+            "storage" => "configuration"
+        },
+        "release-codename" => {
+            "type" => STRING,
+            "description" => "The codename of the WildFly Core release that is being run by the host controller that is acting as the domain controller.",
+            "expressions-allowed" => false,
+            "required" => true,
+            "nillable" => false,
+            "min-length" => 1L,
+            "max-length" => 2147483647L,
+            "access-type" => "read-only",
+            "storage" => "configuration"
+        },
+        "release-version" => {
+            "type" => STRING,
+            "description" => "The version of the WildFly Core release that is being run by the host controller that is acting as the domain controller.",
+            "expressions-allowed" => false,
+            "required" => true,
+            "nillable" => false,
+            "min-length" => 1L,
+            "max-length" => 2147483647L,
+            "access-type" => "read-only",
+            "storage" => "configuration"
+        },
+        "schema-locations" => {
+            "type" => OBJECT,
+            "description" => "Map of locations of XML schemas used in the configuration XML document, where keys are schema URIs and values are locations where the schema can be found.",
+            "expressions-allowed" => false,
+            "required" => true,
+            "nillable" => false,
+            "value-type" => STRING,
+            "access-type" => "read-only",
+            "storage" => "configuration"
+        }
+    },
+    "operations" => {
+        "read-children-types" => {
+            "operation-name" => "read-children-types",
+            "description" => "Gets the type names of all the children under the selected resource",
+            "request-properties" => {
+                "include-aliases" => {
+                    "type" => BOOLEAN,
+                    "description" => "If 'true' include children which are aliases.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "include-singletons" => {
+                    "type" => BOOLEAN,
+                    "description" => "If 'true' include the full key/value pair for any singleton registration.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                }
+            },
+            "reply-properties" => {
+                "type" => LIST,
+                "value-type" => STRING,
+                "description" => "The children types"
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "whoami" => {
+            "operation-name" => "whoami",
+            "description" => "Returns the identity of the currently authenticated user.",
+            "request-properties" => {"verbose" => {
+                "type" => BOOLEAN,
+                "description" => "If set to true whoami also returns the users roles.",
+                "expressions-allowed" => false,
+                "required" => false,
+                "nillable" => true,
+                "default" => false
+            }},
+            "reply-properties" => {
+                "type" => STRING,
+                "description" => "The identify of the authenticated user and their roles if requested."
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "map-clear" => {
+            "operation-name" => "map-clear",
+            "description" => "Clear all entries from map attribute",
+            "request-properties" => {"name" => {
+                "type" => STRING,
+                "description" => "Name of list attribute",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => false,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            }},
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "add-namespace" => {
+            "operation-name" => "add-namespace",
+            "description" => "Adds a namespace prefix mapping to the namespaces attribute's map.",
+            "request-properties" => {
+                "namespace" => {
+                    "type" => STRING,
+                    "description" => "The prefix of the namespace to add",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false
+                },
+                "uri" => {
+                    "type" => STRING,
+                    "description" => "The schema uri of the namespace to add.",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "list-get" => {
+            "operation-name" => "list-get",
+            "description" => "Get entry from list attribute",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "Name of list attribute",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "index" => {
+                    "type" => INT,
+                    "description" => "Index entry to get",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "list-snapshots" => {
+            "operation-name" => "list-snapshots",
+            "description" => "Lists the snapshots",
+            "request-properties" => {},
+            "reply-properties" => {
+                "type" => OBJECT,
+                "value-type" => {
+                    "directory" => {
+                        "type" => STRING,
+                        "description" => "The directory where the snapshots are stored",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "names" => {
+                        "type" => LIST,
+                        "description" => "The names of the snapshots within the snapshots directory",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "min-length" => 0L,
+                        "max-length" => 2147483647L,
+                        "value-type" => STRING
+                    }
+                }
+            },
+            "access-constraints" => {"sensitive" => {"snapshots" => {"type" => "core"}}},
+            "read-only" => true,
+            "runtime-only" => true
+        },
+        "write-attribute" => {
+            "operation-name" => "write-attribute",
+            "description" => "Sets the value of an attribute for the selected resource",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "The name of the attribute to set the value for under the selected resource",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "value" => {
+                    "type" => STRING,
+                    "description" => "The value of the attribute to set the value for under the selected resource. May be null if the underlying model supports null values.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "stop-servers" => {
+            "operation-name" => "stop-servers",
+            "description" => "Stops all servers currently running in the domain.",
+            "request-properties" => {
+                "blocking" => {
+                    "type" => BOOLEAN,
+                    "description" => "Wait until the servers are stopped before returning from the operation.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "timeout" => {
+                    "type" => INT,
+                    "description" => "The graceful shutdown timeout. If this is zero then a graceful shutdown will not be attempted, if this is -1 then the server will wait for a graceful shutdown indefinitely.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => 0,
+                    "unit" => "SECONDS",
+                    "alternatives" => ["suspend-timeout"],
+                    "deprecated" => {
+                        "since" => "9.0.0",
+                        "reason" => "Use suspend-timeout instead."
+                    }
+                },
+                "suspend-timeout" => {
+                    "type" => INT,
+                    "description" => "The graceful stop timeout in seconds. If this is zero (the default) then the server will stop immediately. A value larger than zero means the server will wait up to this many seconds for all active requests to finish. A value smaller than zero means that the server will wait indefinitely for all active requests to finish.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => 0,
+                    "unit" => "SECONDS",
+                    "alternatives" => ["timeout"]
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "take-snapshot" => {
+            "operation-name" => "take-snapshot",
+            "description" => "Takes a snapshot of the current configuration",
+            "request-properties" => {
+                "comment" => {
+                    "type" => STRING,
+                    "description" => "Comment on the snapshot being taken.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "name" => {
+                    "type" => STRING,
+                    "description" => "The name of the snapshot being taken.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                }
+            },
+            "reply-properties" => {
+                "type" => STRING,
+                "description" => "The location of the file on the machine the configuration belongs"
+            },
+            "access-constraints" => {"sensitive" => {"snapshots" => {"type" => "core"}}},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "add-schema-location" => {
+            "operation-name" => "add-schema-location",
+            "description" => "Adds a schema location mapping to the schema-locations attribute's map.",
+            "request-properties" => {
+                "schema-location" => {
+                    "type" => STRING,
+                    "description" => "The location  where the added schema can be found.",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false
+                },
+                "uri" => {
+                    "type" => STRING,
+                    "description" => "The uri of the schema location to add",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "list-add" => {
+            "operation-name" => "list-add",
+            "description" => "Add entry to list attribute",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "Name of list attribute to add entry to",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "value" => {
+                    "type" => STRING,
+                    "description" => "Value to add to list",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "index" => {
+                    "type" => INT,
+                    "description" => "Optional 0 based index where to insert value to",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "map-put" => {
+            "operation-name" => "map-put",
+            "description" => "Add entry to map attribute",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "Name of map attribute to add entry to",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "key" => {
+                    "type" => STRING,
+                    "description" => "Key under which value will be added",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "value" => {
+                    "type" => STRING,
+                    "description" => "Value to be added",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "validate-address" => {
+            "operation-name" => "validate-address",
+            "description" => "Checks whether a resource with the address passed in as the argument exists.",
+            "request-properties" => {"value" => {
+                "type" => OBJECT,
+                "description" => "The address to check.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => false
+            }},
+            "reply-properties" => {
+                "type" => OBJECT,
+                "value-type" => {
+                    "valid" => {
+                        "type" => BOOLEAN,
+                        "description" => "Indicates whether a resource with the address passed in as the argument exists.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false
+                    },
+                    "problem" => {
+                        "type" => STRING,
+                        "description" => "Is included only if the address is not valid and describes what's wrong with the address.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "description" => "Report of checking the address."
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "read-attribute-group-names" => {
+            "operation-name" => "read-attribute-group-names",
+            "description" => "Gets the names of all the attribute groups under the selected resource",
+            "request-properties" => {},
+            "reply-properties" => {
+                "type" => LIST,
+                "value-type" => STRING
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "restart-servers" => {
+            "operation-name" => "restart-servers",
+            "description" => "Restarts all servers currently running in the domain.",
+            "request-properties" => {
+                "blocking" => {
+                    "type" => BOOLEAN,
+                    "description" => "Wait until the servers are fully started before returning from the operation.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "start-mode" => {
+                    "type" => STRING,
+                    "description" => "The mode the servers should restart in, can be either suspend or normal.",
+                    "expressions-allowed" => true,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => "normal",
+                    "allowed" => [
+                        "normal",
+                        "suspend"
+                    ]
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "resume-servers" => {
+            "operation-name" => "resume-servers",
+            "description" => "Resumes processing on all servers in the domain",
+            "request-properties" => {},
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "composite" => {
+            "operation-name" => "composite",
+            "description" => "An operation that groups multiple operation requests into a single operation request.",
+            "request-properties" => {"steps" => {
+                "type" => LIST,
+                "description" => "A list of the operation requests that constitute the composite request.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => false,
+                "min-length" => 0L,
+                "max-length" => 2147483647L,
+                "value-type" => OBJECT
+            }},
+            "reply-properties" => {
+                "type" => OBJECT,
+                "value-type" => OBJECT,
+                "description" => "A composite operation response that consists of all the step results."
+            },
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "delete-snapshot" => {
+            "operation-name" => "delete-snapshot",
+            "description" => "Deletes a snapshot from the snapshots directory",
+            "request-properties" => {"name" => {
+                "type" => STRING,
+                "description" => "The name of the snapshot to delete. The whole name is not needed, as long as what is passed in uniquely identifies a snapshot within the snapshots directory. If 'all' is used, all snapshots in the snapshot directory will be deleted.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => false,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            }},
+            "reply-properties" => {},
+            "access-constraints" => {"sensitive" => {"snapshots" => {"type" => "core"}}},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "validate-operation" => {
+            "operation-name" => "validate-operation",
+            "description" => "Validates that an operation is valid according to its description. Any errors present will be shown in the operation's failure-description.",
+            "request-properties" => {"value" => {
+                "type" => OBJECT,
+                "description" => "The operation to validate.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => false
+            }},
+            "reply-properties" => {},
+            "read-only" => true,
+            "runtime-only" => true
+        },
+        "read-resource-description" => {
+            "operation-name" => "read-resource-description",
+            "description" => "Gets the description of a resource's attributes, types of children and, optionally, operations",
+            "request-properties" => {
+                "operations" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include descriptions of the resource's operations. Default is false",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "notifications" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include descriptions of the resource's notifications. Default is false",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "inherited" => {
+                    "type" => BOOLEAN,
+                    "description" => "If 'operations' is true, whether to include descriptions of the resource's inherited operations. Default is true.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => true
+                },
+                "recursive" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include recursively descriptions of child resources. Default is false.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true
+                },
+                "recursive-depth" => {
+                    "type" => INT,
+                    "description" => "The depth to which information about child resources should be included.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min" => 0L,
+                    "max" => 2147483647L
+                },
+                "proxies" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include remote resources in a recursive query (i.e. host level resources in a query of the domain root; running server resources in a query of a host). If absent, false is the default",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "include-aliases" => {
+                    "type" => BOOLEAN,
+                    "description" => "If 'true' and recursive, include children which are aliases.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "access-control" => {
+                    "type" => STRING,
+                    "description" => "Include information about what rights the current user has on the actual resources, attributes and operations.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => "none",
+                    "allowed" => [
+                        "none",
+                        "combined-descriptions",
+                        "trim-descriptions"
+                    ]
+                },
+                "locale" => {
+                    "type" => STRING,
+                    "description" => "The locale to get the resource description in. If null, the default locale will be used",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                }
+            },
+            "reply-properties" => {
+                "type" => OBJECT,
+                "description" => "The description of the resource"
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "read-resource" => {
+            "operation-name" => "read-resource",
+            "description" => "Reads a model resource's attribute values along with either basic or complete information about any child resources",
+            "request-properties" => {
+                "recursive" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include complete information about child resources, recursively. If absent, false is the default",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true
+                },
+                "recursive-depth" => {
+                    "type" => INT,
+                    "description" => "The depth to which information about child resources should be included.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min" => 0L,
+                    "max" => 2147483647L
+                },
+                "proxies" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include remote resources in a recursive query (i.e. host level resources in a query of the domain root; running server resources in a query of a host). If absent, false is the default.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "include-runtime" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include runtime attributes (i.e. those whose value does not come from the persistent configuration) in the response. If absent, false is the default.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "include-defaults" => {
+                    "type" => BOOLEAN,
+                    "description" => "Boolean to enable/disable default reading. In case it is set to false only attribute set by user are returned ignoring undefined.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => true
+                },
+                "attributes-only" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether or not to only read the attributes on the specified resource. Cannot be used in conjunction with 'recursive' or 'recursive-depth'.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "include-aliases" => {
+                    "type" => BOOLEAN,
+                    "description" => "If 'true' and recursive, include children which are aliases.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "include-undefined-metric-values" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include undefined metric values. If the underlying metric value can not be computed, this flag ensures that the value will remain undefined (without being replaced by a possible 'undefined metric value' from the attribute definition.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                }
+            },
+            "reply-properties" => {
+                "type" => OBJECT,
+                "description" => "The resource's attribute values along with information about any child resources"
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "remove-schema-location" => {
+            "operation-name" => "remove-schema-location",
+            "description" => "Removes a schema location mapping from the schema-locations attribute's map.",
+            "request-properties" => {"uri" => {
+                "type" => STRING,
+                "description" => "The URI of the schema location to remove.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => false
+            }},
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "suspend-servers" => {
+            "operation-name" => "suspend-servers",
+            "description" => "Suspends all servers in the domain, all current operations will finish, and no new operations will be allowed.",
+            "request-properties" => {
+                "timeout" => {
+                    "type" => INT,
+                    "description" => "Timeout in seconds. If this is zero the operation will return immediately, -1 means that it will wait indefinitely. Note that the operation will not roll back if the timeout is exceeded, it just means that not all current requests completed in the specified timeout.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => 0,
+                    "unit" => "SECONDS",
+                    "alternatives" => ["suspend-timeout"],
+                    "deprecated" => {
+                        "since" => "9.0.0",
+                        "reason" => "Use suspend-timeout instead."
+                    }
+                },
+                "suspend-timeout" => {
+                    "type" => INT,
+                    "description" => "The suspend operation timeout in seconds. If this is zero (the default) the operation will return immediately. A value larger than zero means the operation will wait up to this many seconds to complete before returning. A value smaller than zero means that the operation will wait indefinitely for all active requests to finish. Note that the operation will not roll back if the timeout is exceeded, it just means that not all current requests completed in the specified timeout.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => 0,
+                    "unit" => "SECONDS",
+                    "alternatives" => ["timeout"]
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "reload-servers" => {
+            "operation-name" => "reload-servers",
+            "description" => "Reloads all servers currently running in the domain.",
+            "request-properties" => {
+                "blocking" => {
+                    "type" => BOOLEAN,
+                    "description" => "Wait until the servers are fully started before returning from the operation.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "start-mode" => {
+                    "type" => STRING,
+                    "description" => "The mode the servers should reload in, can be either suspend or normal.",
+                    "expressions-allowed" => true,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => "normal",
+                    "allowed" => [
+                        "normal",
+                        "suspend"
+                    ]
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "full-replace-deployment" => {
+            "operation-name" => "full-replace-deployment",
+            "description" => "Add previously uploaded deployment content to the list of content available for use, replace existing content of the same name in the runtime, and remove the replaced content from the list of content available for use. This is equivalent to an 'add', 'undeploy', 'deploy', 'remove' sequence where the new content has the same name as the content being replaced. Precisely one of 'runtime-name', 'hash', 'input-stream-index', 'bytes' or 'url' must be specified.",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "Unique identifier of the deployment. Must be unique across all deployments.",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "runtime-name" => {
+                    "type" => STRING,
+                    "description" => "Name by which the deployment should be known within a server's runtime. This would be equivalent to the file name of a deployment file, and would form the basis for such things as default Java Enterprise Edition application and module names. This would typically be the same as 'name', but in some cases users may wish to have two deployments with the same 'runtime-name' (e.g. two versions of \"foo.war\") both available in the deployment content repository, in which case the deployments would need to have distinct 'name' values but would have the same 'runtime-name'.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "content" => {
+                    "type" => LIST,
+                    "description" => "List of pieces of content that comprise the deployment.",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 1L,
+                    "value-type" => {
+                        "input-stream-index" => {
+                            "type" => INT,
+                            "description" => "The index into the operation's attached input streams of the input stream that contains deployment content that should be uploaded to the domain's or standalone server's deployment content repository.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => true,
+                            "alternatives" => [
+                                "hash",
+                                "bytes",
+                                "url",
+                                "path",
+                                "relative-to",
+                                "empty"
+                            ],
+                            "min" => 1L,
+                            "max" => 2147483647L,
+                            "filesystem-path" => true,
+                            "attached-streams" => true
+                        },
+                        "hash" => {
+                            "type" => BYTES,
+                            "description" => "The hash of managed deployment content that has been uploaded to the domain's or standalone server's deployment content repository.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => true,
+                            "alternatives" => [
+                                "input-stream-index",
+                                "bytes",
+                                "url",
+                                "path",
+                                "relative-to",
+                                "empty"
+                            ],
+                            "min-length" => 20L,
+                            "max-length" => 20L
+                        },
+                        "bytes" => {
+                            "type" => BYTES,
+                            "description" => "Byte array containing the deployment content that should uploaded to the domain's or standalone server's deployment content repository.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => true,
+                            "alternatives" => [
+                                "input-stream-index",
+                                "hash",
+                                "url",
+                                "path",
+                                "relative-to",
+                                "empty"
+                            ]
+                        },
+                        "url" => {
+                            "type" => STRING,
+                            "description" => "The URL at which the deployment content is available for upload to the domain's or standalone server's deployment content repository.. Note that the URL must be accessible from the target of the operation (i.e. the Domain Controller or standalone server).",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => true,
+                            "alternatives" => [
+                                "input-stream-index",
+                                "hash",
+                                "bytes",
+                                "path",
+                                "relative-to",
+                                "empty"
+                            ],
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "path" => {
+                            "type" => STRING,
+                            "description" => "Path (relative or absolute) to unmanaged content that is part of the deployment.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => true,
+                            "alternatives" => [
+                                "input-stream-index",
+                                "hash",
+                                "bytes",
+                                "url",
+                                "empty"
+                            ],
+                            "requires" => ["archive"],
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "relative-to" => {
+                            "type" => STRING,
+                            "description" => "Name of a system path to which the value of the 'path' is relative. If not set, the 'path' is considered to be absolute.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "alternatives" => [
+                                "input-stream-index",
+                                "hash",
+                                "bytes",
+                                "url",
+                                "empty"
+                            ],
+                            "requires" => ["path"],
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "archive" => {
+                            "type" => BOOLEAN,
+                            "description" => "Flag indicating whether unmanaged content is a zip archive (true) or exploded (false).",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "alternatives" => [
+                                "input-stream-index",
+                                "bytes",
+                                "url"
+                            ],
+                            "requires" => [
+                                "path",
+                                "hash",
+                                "empty"
+                            ]
+                        },
+                        "empty" => {
+                            "type" => BOOLEAN,
+                            "description" => "Indicates that the deployment to be added is empty - so without any content.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => true,
+                            "default" => false,
+                            "alternatives" => [
+                                "hash",
+                                "input-stream-index",
+                                "bytes",
+                                "url",
+                                "path",
+                                "relative-to"
+                            ]
+                        }
+                    }
+                },
+                "enabled" => {
+                    "type" => BOOLEAN,
+                    "description" => "Boolean indicating whether the replacement deployment content should be deployed in the runtime (or should be deployed in the runtime the next time the server starts.) An undefined value indicates the state of the existing deployment should be retained.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                }
+            },
+            "reply-properties" => {},
+            "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "query" => {
+            "operation-name" => "query",
+            "description" => "query a resource",
+            "request-properties" => {
+                "select" => {
+                    "type" => LIST,
+                    "description" => "a list of attribute names to reduce to",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 0L,
+                    "max-length" => 2147483647L,
+                    "value-type" => STRING
+                },
+                "where" => {
+                    "type" => OBJECT,
+                    "description" => "a list of filter criteria tuples (i.e. 'running=true')",
+                    "expressions-allowed" => true,
+                    "required" => false,
+                    "nillable" => true,
+                    "value-type" => STRING
+                }
+            },
+            "reply-properties" => {
+                "type" => LIST,
+                "value-type" => OBJECT
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "read-operation-description" => {
+            "operation-name" => "read-operation-description",
+            "description" => "Gets description of given operation",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "Name of operation",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "locale" => {
+                    "type" => STRING,
+                    "description" => "Locale in which to return description",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "access-control" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether or not to include information about what rights the current user has on the operation.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                }
+            },
+            "reply-properties" => {"type" => OBJECT},
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "map-get" => {
+            "operation-name" => "map-get",
+            "description" => "Get entry from map attribute",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "Name of map attribute",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "key" => {
+                    "type" => STRING,
+                    "description" => "Key of entry to return",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "list-clear" => {
+            "operation-name" => "list-clear",
+            "description" => "Clear all entries from list attribute",
+            "request-properties" => {"name" => {
+                "type" => STRING,
+                "description" => "Name of list attribute",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => false,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            }},
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "write-config" => {
+            "operation-name" => "write-config",
+            "description" => "An operation to force the server to write its config file, without making any actual config change.",
+            "request-properties" => {},
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "upload-deployment-bytes" => {
+            "operation-name" => "upload-deployment-bytes",
+            "description" => "Indicates that the deployment content in the included byte array should be added to the deployment content repository. Note that this operation does not indicate the content should be deployed into the runtime.",
+            "request-properties" => {"bytes" => {
+                "type" => BYTES,
+                "description" => "Byte array containing the deployment content that should uploaded to the domain's or standalone server's deployment content repository.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => true,
+                "alternatives" => [
+                    "input-stream-index",
+                    "hash",
+                    "url",
+                    "path",
+                    "relative-to",
+                    "empty"
+                ]
+            }},
+            "reply-properties" => {
+                "type" => BYTES,
+                "description" => "The hash of managed deployment content that has been uploaded to the domain's or standalone server's deployment content repository.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => true,
+                "alternatives" => [
+                    "input-stream-index",
+                    "bytes",
+                    "url",
+                    "path",
+                    "relative-to",
+                    "empty"
+                ],
+                "min-length" => 20L,
+                "max-length" => 20L
+            },
+            "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "read-attribute" => {
+            "operation-name" => "read-attribute",
+            "description" => "Gets the value of an attribute for the selected resource",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "The name of the attribute to get the value for under the selected resource",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "include-defaults" => {
+                    "type" => BOOLEAN,
+                    "description" => "Boolean to enable/disable default reading. In case it is set to false only attribute set by user are returned ignoring undefined.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => true
+                },
+                "include-undefined-metric-values" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include undefined metric. If the underlying metric value can not be computed, this flag ensures that the value will remain undefined (without being replaced by a possible 'undefined metric valur' from the attribute definition.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                }
+            },
+            "reply-properties" => {
+                "type" => OBJECT,
+                "description" => "The value of the attribute. The type will be that of the attribute found"
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "upload-deployment-url" => {
+            "operation-name" => "upload-deployment-url",
+            "description" => "Indicates that the deployment content available at the included URL should be added to the deployment content repository. Note that this operation does not indicate the content should be deployed into the runtime.",
+            "request-properties" => {"url" => {
+                "type" => STRING,
+                "description" => "The URL at which the deployment content is available for upload to the domain's or standalone server's deployment content repository.. Note that the URL must be accessible from the target of the operation (i.e. the Domain Controller or standalone server).",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => true,
+                "alternatives" => [
+                    "input-stream-index",
+                    "hash",
+                    "bytes",
+                    "path",
+                    "relative-to",
+                    "empty"
+                ],
+                "min-length" => 1L,
+                "max-length" => 2147483647L,
+                "web-url" => true
+            }},
+            "reply-properties" => {
+                "type" => BYTES,
+                "description" => "The hash of managed deployment content that has been uploaded to the domain's or standalone server's deployment content repository.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => true,
+                "alternatives" => [
+                    "input-stream-index",
+                    "bytes",
+                    "url",
+                    "path",
+                    "relative-to",
+                    "empty"
+                ],
+                "min-length" => 20L,
+                "max-length" => 20L
+            },
+            "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "map-remove" => {
+            "operation-name" => "map-remove",
+            "description" => "Remove entry from map attribute",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "Name of map attribute",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "key" => {
+                    "type" => STRING,
+                    "description" => "Key of entry to remove",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "read-config-as-xml" => {
+            "operation-name" => "read-config-as-xml",
+            "description" => "Reads the current configuration and returns it in XML format.",
+            "request-properties" => {},
+            "reply-properties" => {"type" => STRING},
+            "access-constraints" => {"sensitive" => {"read-whole-config" => {"type" => "core"}}},
+            "read-only" => true,
+            "runtime-only" => true
+        },
+        "read-attribute-group" => {
+            "operation-name" => "read-attribute-group",
+            "description" => "Gets the value of attributes for the selected group",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "Name of the group to get the attribute",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "include-runtime" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include runtime attributes (i.e. those whose value does not come from the persistent configuration) in the response. If absent, false is the default.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "include-defaults" => {
+                    "type" => BOOLEAN,
+                    "description" => "Boolean to enable/disable default reading. In case it is set to false only attribute set by user are returned ignoring undefined.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => true
+                },
+                "include-aliases" => {
+                    "type" => BOOLEAN,
+                    "description" => "If 'true' include attributes which are aliases.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                }
+            },
+            "reply-properties" => {
+                "type" => LIST,
+                "value-type" => PROPERTY,
+                "description" => "The attributes"
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "undefine-attribute" => {
+            "operation-name" => "undefine-attribute",
+            "description" => "Sets the value of an attribute of the selected resource to 'undefined'",
+            "request-properties" => {"name" => {
+                "type" => STRING,
+                "description" => "The name of the attribute which should be set to 'undefined'",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => false,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            }},
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "read-children-names" => {
+            "operation-name" => "read-children-names",
+            "description" => "Gets the names of all children under the selected resource with the given type",
+            "request-properties" => {
+                "child-type" => {
+                    "type" => STRING,
+                    "description" => "The name of the node under which to get the children names",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "include-singletons" => {
+                    "type" => BOOLEAN,
+                    "description" => "If 'true' include the allowed values for any singleton registration, even if no resource currently exists with that name.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                }
+            },
+            "reply-properties" => {
+                "type" => LIST,
+                "value-type" => STRING,
+                "description" => "The children names"
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "start-servers" => {
+            "operation-name" => "start-servers",
+            "description" => "Starts all configured servers in the domain that are not currently running.",
+            "request-properties" => {
+                "blocking" => {
+                    "type" => BOOLEAN,
+                    "description" => "Wait until the servers are fully started before returning from the operation.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "start-mode" => {
+                    "type" => STRING,
+                    "description" => "The mode the servers should start running in, can be either suspend or normal.",
+                    "expressions-allowed" => true,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => "normal",
+                    "allowed" => [
+                        "normal",
+                        "suspend"
+                    ]
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "read-operation-names" => {
+            "operation-name" => "read-operation-names",
+            "description" => "Gets the names of all the operations for the given resource",
+            "request-properties" => {"access-control" => {
+                "type" => BOOLEAN,
+                "description" => "If 'true' only operations the user is allowed to see are returned, and filtered operations are listed in the 'access-control' response header.",
+                "expressions-allowed" => false,
+                "required" => false,
+                "nillable" => true,
+                "default" => false
+            }},
+            "reply-properties" => {
+                "type" => LIST,
+                "value-type" => STRING,
+                "description" => "The operation names"
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "list-remove" => {
+            "operation-name" => "list-remove",
+            "description" => "Remove entry from list attribute",
+            "request-properties" => {
+                "name" => {
+                    "type" => STRING,
+                    "description" => "Name of list attribute to remove entry from",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "value" => {
+                    "type" => STRING,
+                    "description" => "Value remove from list",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "index" => {
+                    "type" => INT,
+                    "description" => "Optional 0 based index to tell what element to remove",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true
+                }
+            },
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        },
+        "read-children-resources" => {
+            "operation-name" => "read-children-resources",
+            "description" => "Reads information about all of a resource's children that are of a given type",
+            "request-properties" => {
+                "child-type" => {
+                    "type" => STRING,
+                    "description" => "The name of the resource under which to get the child resources",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                },
+                "recursive" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to get the children recursively. If absent, false is the default",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true
+                },
+                "recursive-depth" => {
+                    "type" => INT,
+                    "description" => "The depth to which information about child resources should be included.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min" => 0L,
+                    "max" => 2147483647L
+                },
+                "proxies" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include remote resources in a recursive query (i.e. host level resources in a query of the domain root; running server resources in a query of a host). If absent, false is the default",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "include-runtime" => {
+                    "type" => BOOLEAN,
+                    "description" => "Whether to include runtime attributes (i.e. those whose value does not come from the persistent configuration) in the response. If absent, false is the default. Ignored if the 'recursive' parameter is set to 'true'; i.e. runtime attributes can only be read in non-recursive queries.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => false
+                },
+                "include-defaults" => {
+                    "type" => BOOLEAN,
+                    "description" => "Boolean to enable/disable default reading. In case it is set to false only attribute set by user are returned ignoring undefined.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "default" => true
+                }
+            },
+            "reply-properties" => {
+                "type" => LIST,
+                "value-type" => OBJECT,
+                "description" => "The children resources"
+            },
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "resolve-expression-on-domain" => {
+            "operation-name" => "resolve-expression-on-domain",
+            "description" => "Operation that accepts an expression as input (or a string that can be parsed into an expression) and resolves it against the local system properties and environment variables on all servers in the domain.",
+            "request-properties" => {"expression" => {
+                "type" => STRING,
+                "description" => "The expression to resolve.",
+                "expressions-allowed" => true,
+                "required" => false,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            }},
+            "reply-properties" => {
+                "type" => STRING,
+                "description" => "The resolved expression, or the string form of the original input value if it did not represent an expression.",
+                "nillable" => true
+            },
+            "access-constraints" => {"sensitive" => {"system-property" => {"type" => "core"}}},
+            "read-only" => true,
+            "runtime-only" => false
+        },
+        "upload-deployment-stream" => {
+            "operation-name" => "upload-deployment-stream",
+            "description" => "Indicates that the deployment content available at the included input stream index should be added to the deployment content repository. Note that this operation does not indicate the content should be deployed into the runtime.",
+            "request-properties" => {"input-stream-index" => {
+                "type" => INT,
+                "description" => "The index into the operation's attached input streams of the input stream that contains deployment content that should be uploaded to the domain's or standalone server's deployment content repository.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => true,
+                "alternatives" => [
+                    "hash",
+                    "bytes",
+                    "url",
+                    "path",
+                    "relative-to",
+                    "empty"
+                ],
+                "min" => 1L,
+                "max" => 2147483647L,
+                "filesystem-path" => true,
+                "attached-streams" => true
+            }},
+            "reply-properties" => {
+                "type" => BYTES,
+                "description" => "The hash of managed deployment content that has been uploaded to the domain's or standalone server's deployment content repository.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => true,
+                "alternatives" => [
+                    "input-stream-index",
+                    "bytes",
+                    "url",
+                    "path",
+                    "relative-to",
+                    "empty"
+                ],
+                "min-length" => 20L,
+                "max-length" => 20L
+            },
+            "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+            "read-only" => false,
+            "runtime-only" => true
+        },
+        "product-info" => {
+            "operation-name" => "product-info",
+            "description" => "Get product info report",
+            "request-properties" => {},
+            "reply-properties" => {
+                "type" => LIST,
+                "value-type" => {"summary" => {
+                    "type" => OBJECT,
+                    "description" => "Summary of the current server installation.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "value-type" => {
+                        "node-name" => {
+                            "type" => STRING,
+                            "description" => "The name of the instance node.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "host-name" => {
+                            "type" => STRING,
+                            "description" => "The name to use for this host's host controller. Must be unique across the domain. If not set, defaults to the runtime value of InetAddress.getLocalHost().getHostName().",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "instance-identifier" => {
+                            "type" => STRING,
+                            "description" => "Unique Id of the server instance.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "product-name" => {
+                            "type" => STRING,
+                            "description" => "The name of the product that is being run by this server.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "product-community-identifier" => {
+                            "type" => STRING,
+                            "description" => "Indicates the type of distribution, if it is a Product or a Project.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => false,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L,
+                            "allowed" => [
+                                "Product",
+                                "Project"
+                            ]
+                        },
+                        "product-version" => {
+                            "type" => STRING,
+                            "description" => "The version of the product release that is being run by this server.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "product-home" => {
+                            "type" => STRING,
+                            "description" => "Installation directory of the current server instance.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "installation-date" => {
+                            "type" => STRING,
+                            "description" => "Installation date of the current server instance.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "last-update-date" => {
+                            "type" => STRING,
+                            "description" => "Date of the last update of the current product.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "host-operating-system" => {
+                            "type" => STRING,
+                            "description" => "The name of the Operating System.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => false,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "jvm" => {
+                            "type" => OBJECT,
+                            "description" => "The JVM configuration for the server.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => false,
+                            "value-type" => {
+                                "java-version" => {
+                                    "type" => STRING,
+                                    "description" => "The Java language version.",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "jvm-version" => {
+                                    "type" => STRING,
+                                    "description" => "The complete build version of the JVM.",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "jvm-vendor" => {
+                                    "type" => STRING,
+                                    "description" => "The vendor of the JVM.",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "java-home" => {
+                                    "type" => STRING,
+                                    "description" => "The path to the JVM used by the server instance.",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                }
+                            }
+                        },
+                        "host-cpu" => {
+                            "type" => OBJECT,
+                            "description" => "The description of the host CPU (as generated by JVM).",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => false,
+                            "value-type" => {
+                                "host-cpu-arch" => {
+                                    "type" => STRING,
+                                    "description" => "The CPU architecture of the host (as generated by JVM).",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "host-core-count" => {
+                                    "type" => INT,
+                                    "description" => "The number of cores available on the host (as generated by JVM).",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => 1
+                                }
+                            }
+                        }
+                    }
+                }}
+            },
+            "read-only" => true,
+            "runtime-only" => true
+        },
+        "remove-namespace" => {
+            "operation-name" => "remove-namespace",
+            "description" => "Removes a namespace prefix mapping from the namespaces attribute's map.",
+            "request-properties" => {"namespace" => {
+                "type" => STRING,
+                "description" => "The prefix of the namespace to remove.",
+                "expressions-allowed" => false,
+                "required" => true,
+                "nillable" => false
+            }},
+            "reply-properties" => {},
+            "read-only" => false,
+            "runtime-only" => false
+        }
+    },
+    "notifications" => undefined,
+    "children" => {
+        "profile" => {
+            "description" => "A list of profiles available for use in the domain",
+            "model-description" => {"*" => {
+                "description" => "A named set of subsystem configurations.",
+                "capabilities" => [{
+                    "name" => "org.wildfly.domain.profile",
+                    "dynamic" => true,
+                    "dynamic-elements" => ["profile"]
+                }],
+                "attributes" => {
+                    "includes" => {
+                        "type" => LIST,
+                        "description" => "A list of the names of profiles to include in this profile. Overriding subsystems is not supported.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "capability-reference" => "org.wildfly.domain.profile",
+                        "min-length" => 0L,
+                        "max-length" => 2147483647L,
+                        "value-type" => STRING,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The name of the profile",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-only",
+                        "storage" => "configuration"
+                    }
+                },
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Add a new 'profile'",
+                        "request-properties" => {"includes" => {
+                            "type" => LIST,
+                            "description" => "A list of the names of profiles to include in this profile. Overriding subsystems is not supported.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "capability-reference" => "org.wildfly.domain.profile",
+                            "min-length" => 0L,
+                            "max-length" => 2147483647L,
+                            "value-type" => STRING
+                        }},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "clone" => {
+                        "operation-name" => "clone",
+                        "description" => "Clones this profile to a new one. The clone is a copy of all this profile's configuration and subsystems.",
+                        "request-properties" => {"to-profile" => {
+                            "type" => STRING,
+                            "description" => "The name of the new profile to be created.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => false,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "reply-properties" => {},
+                        "access-constraints" => {"sensitive" => {"read-whole-config" => {"type" => "core"}}},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Remove a 'profile'",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "restart-required" => "all-services",
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => []
+            }}
+        },
+        "socket-binding-group" => {
+            "description" => "A list of socket binding groups available for use in the domain",
+            "model-description" => {"*" => {
+                "description" => "Contains a list of socket configurations.",
+                "capabilities" => [{
+                    "name" => "org.wildfly.domain.socket-binding-group",
+                    "dynamic" => true,
+                    "dynamic-elements" => ["socket-binding-group"]
+                }],
+                "access-constraints" => {"sensitive" => {"socket-config" => {"type" => "core"}}},
+                "attributes" => {
+                    "default-interface" => {
+                        "type" => STRING,
+                        "description" => "Name of an interface that should be used as the interface for any sockets that do not explicitly declare one.",
+                        "expressions-allowed" => true,
+                        "required" => true,
+                        "nillable" => false,
+                        "capability-reference" => "org.wildfly.network.interface",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "includes" => {
+                        "type" => LIST,
+                        "description" => "A list of socket binding group names whose bindings are to be included in this socket-binding-group. This binding group's default interface will be applied to any included  bindings that do not specify an interface.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "capability-reference" => "org.wildfly.domain.socket-binding-group",
+                        "min-length" => 0L,
+                        "max-length" => 2147483647L,
+                        "value-type" => STRING,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The name of the socket binding group.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-only",
+                        "storage" => "configuration"
+                    }
+                },
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Adds a socket binding group.",
+                        "request-properties" => {
+                            "default-interface" => {
+                                "type" => STRING,
+                                "description" => "Name of an interface that should be used as the interface for any sockets that do not explicitly declare one.",
+                                "expressions-allowed" => true,
+                                "required" => true,
+                                "nillable" => false,
+                                "capability-reference" => "org.wildfly.network.interface",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "includes" => {
+                                "type" => LIST,
+                                "description" => "A list of socket binding group names whose bindings are to be included in this socket-binding-group. This binding group's default interface will be applied to any included  bindings that do not specify an interface.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "capability-reference" => "org.wildfly.domain.socket-binding-group",
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Removes a socket binding group.",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "restart-required" => "all-services",
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => {
+                    "local-destination-outbound-socket-binding" => {
+                        "description" => "Configuration information for a local destination outbound socket binding.",
+                        "model-description" => {"*" => {
+                            "description" => "Configuration information for a local destination outbound socket binding.",
+                            "capabilities" => [{
+                                "name" => "org.wildfly.network.outbound-socket-binding",
+                                "dynamic" => true,
+                                "dynamic-elements" => ["local-destination-outbound-socket-binding"]
+                            }],
+                            "access-constraints" => {"sensitive" => {"socket-config" => {"type" => "core"}}},
+                            "attributes" => {
+                                "fixed-source-port" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "Whether the port value should remain fixed even if numeric offsets are applied to the other outbound sockets in the socket group.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => false,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "socket-binding-ref" => {
+                                    "type" => STRING,
+                                    "description" => "The name of the local socket-binding which will be used to determine the port to which this outbound socket connects.",
+                                    "expressions-allowed" => true,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "capability-reference" => "org.wildfly.network.socket-binding",
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-constraints" => {"sensitive" => {"socket-binding-ref" => {"type" => "core"}}},
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "source-interface" => {
+                                    "type" => STRING,
+                                    "description" => "The name of the interface which will be used for the source address of the outbound socket.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "capability-reference" => "org.wildfly.network.interface",
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "source-port" => {
+                                    "type" => INT,
+                                    "description" => "The port number which will be used as the source port of the outbound socket.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min" => 0L,
+                                    "max" => 65535L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                }
+                            },
+                            "operations" => {
+                                "add" => {
+                                    "operation-name" => "add",
+                                    "description" => "Adds a local destination outbound socket binding to a socket binding group",
+                                    "request-properties" => {
+                                        "fixed-source-port" => {
+                                            "type" => BOOLEAN,
+                                            "description" => "Whether the port value should remain fixed even if numeric offsets are applied to the other outbound sockets in the socket group.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "default" => false
+                                        },
+                                        "socket-binding-ref" => {
+                                            "type" => STRING,
+                                            "description" => "The name of the local socket-binding which will be used to determine the port to which this outbound socket connects.",
+                                            "expressions-allowed" => true,
+                                            "required" => true,
+                                            "nillable" => false,
+                                            "capability-reference" => "org.wildfly.network.socket-binding",
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "source-interface" => {
+                                            "type" => STRING,
+                                            "description" => "The name of the interface which will be used for the source address of the outbound socket.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "capability-reference" => "org.wildfly.network.interface",
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "source-port" => {
+                                            "type" => INT,
+                                            "description" => "The port number which will be used as the source port of the outbound socket.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min" => 0L,
+                                            "max" => 65535L
+                                        }
+                                    },
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "remove" => {
+                                    "operation-name" => "remove",
+                                    "description" => "Removes a local destination outbound socket binding from a socket binding group",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "restart-required" => "all-services",
+                                    "runtime-only" => false
+                                }
+                            },
+                            "notifications" => undefined,
+                            "children" => {}
+                        }}
+                    },
+                    "remote-destination-outbound-socket-binding" => {
+                        "description" => "Configuration information for a remote destination outbound socket binding.",
+                        "model-description" => {"*" => {
+                            "description" => "Configuration information for a remote destination outbound socket binding.",
+                            "capabilities" => [{
+                                "name" => "org.wildfly.network.outbound-socket-binding",
+                                "dynamic" => true,
+                                "dynamic-elements" => ["remote-destination-outbound-socket-binding"]
+                            }],
+                            "access-constraints" => {"sensitive" => {"socket-config" => {"type" => "core"}}},
+                            "attributes" => {
+                                "fixed-source-port" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "Whether the port value should remain fixed even if numeric offsets are applied to the other outbound sockets in the socket group.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => false,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "host" => {
+                                    "type" => STRING,
+                                    "description" => "The host name or the IP address of the remote destination to which this outbound socket will connect.",
+                                    "expressions-allowed" => true,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "port" => {
+                                    "type" => INT,
+                                    "description" => "The port number of the remote destination to which the outbound socket should connect.",
+                                    "expressions-allowed" => true,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "min" => 0L,
+                                    "max" => 65535L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "source-interface" => {
+                                    "type" => STRING,
+                                    "description" => "The name of the interface which will be used for the source address of the outbound socket.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "capability-reference" => "org.wildfly.network.interface",
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "source-port" => {
+                                    "type" => INT,
+                                    "description" => "The port number which will be used as the source port of the outbound socket.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min" => 0L,
+                                    "max" => 65535L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                }
+                            },
+                            "operations" => {
+                                "add" => {
+                                    "operation-name" => "add",
+                                    "description" => "Adds a remote destination outbound socket binding to a socket binding group",
+                                    "request-properties" => {
+                                        "fixed-source-port" => {
+                                            "type" => BOOLEAN,
+                                            "description" => "Whether the port value should remain fixed even if numeric offsets are applied to the other outbound sockets in the socket group.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "default" => false
+                                        },
+                                        "host" => {
+                                            "type" => STRING,
+                                            "description" => "The host name or the IP address of the remote destination to which this outbound socket will connect.",
+                                            "expressions-allowed" => true,
+                                            "required" => true,
+                                            "nillable" => false,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "port" => {
+                                            "type" => INT,
+                                            "description" => "The port number of the remote destination to which the outbound socket should connect.",
+                                            "expressions-allowed" => true,
+                                            "required" => true,
+                                            "nillable" => false,
+                                            "min" => 0L,
+                                            "max" => 65535L
+                                        },
+                                        "source-interface" => {
+                                            "type" => STRING,
+                                            "description" => "The name of the interface which will be used for the source address of the outbound socket.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "capability-reference" => "org.wildfly.network.interface",
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "source-port" => {
+                                            "type" => INT,
+                                            "description" => "The port number which will be used as the source port of the outbound socket.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min" => 0L,
+                                            "max" => 65535L
+                                        }
+                                    },
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "remove" => {
+                                    "operation-name" => "remove",
+                                    "description" => "Removes a remote destination outbound socket binding from a socket binding group",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "restart-required" => "all-services",
+                                    "runtime-only" => false
+                                }
+                            },
+                            "notifications" => undefined,
+                            "children" => {}
+                        }}
+                    },
+                    "socket-binding" => {
+                        "description" => "The individual socket configurations.",
+                        "model-description" => {"*" => {
+                            "description" => "Configuration information for a socket.",
+                            "capabilities" => [{
+                                "name" => "org.wildfly.network.socket-binding",
+                                "dynamic" => true,
+                                "dynamic-elements" => ["socket-binding"]
+                            }],
+                            "access-constraints" => {"sensitive" => {"socket-config" => {"type" => "core"}}},
+                            "attributes" => {
+                                "client-mappings" => {
+                                    "type" => LIST,
+                                    "description" => "Specifies zero or more client mappings for this socket binding. A client connecting to this socket should use the destination address specified in the mapping that matches its desired outbound interface. This allows for advanced network topologies that use either network address translation, or have bindings on multiple network interfaces to function. Each mapping should be evaluated in declared order, with the first successful match used to determine the destination.",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 0L,
+                                    "max-length" => 2147483647L,
+                                    "value-type" => {
+                                        "source-network" => {
+                                            "type" => STRING,
+                                            "description" => "Source network the client connection binds on. This value is in the form of ip/netmask. A client should match this value against the desired client host network interface, and if matched the client should connect to the corresponding destination values. If omitted this mapping should match any interface.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true
+                                        },
+                                        "destination-address" => {
+                                            "type" => STRING,
+                                            "description" => "The destination address that a client should connect to if the source-network matches. This value can either be a hostname or an IP address.",
+                                            "expressions-allowed" => true,
+                                            "required" => true,
+                                            "nillable" => false,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "destination-port" => {
+                                            "type" => INT,
+                                            "description" => "The destination port that a client should connect to if the source-network matches. If omitted this mapping will reuse the effective socket binding port.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min" => 0L,
+                                            "max" => 65535L
+                                        }
+                                    },
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "fixed-port" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "Whether the port value should remain fixed even if numeric offsets are applied to the other sockets in the socket group.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => false,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "interface" => {
+                                    "type" => STRING,
+                                    "description" => "Name of the interface to which the socket should be bound, or, for multicast sockets, the interface on which it should listen. This should be one of the declared interfaces.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "capability-reference" => "org.wildfly.network.interface",
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "multicast-address" => {
+                                    "type" => STRING,
+                                    "description" => "Multicast address on which the socket should receive multicast traffic. If unspecified, the socket will not be configured to receive multicast.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "multicast-port" => {
+                                    "type" => INT,
+                                    "description" => "Port on which the socket should receive multicast traffic. Must be configured if 'multicast-address' is configured.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min" => 1L,
+                                    "max" => 65535L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                },
+                                "name" => {
+                                    "type" => STRING,
+                                    "description" => "The name of the socket. Services which need to access the socket configuration information will find it using this name.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-only",
+                                    "storage" => "configuration"
+                                },
+                                "port" => {
+                                    "type" => INT,
+                                    "description" => "Number of the port to which the socket should be bound.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => 0,
+                                    "min" => 0L,
+                                    "max" => 65535L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "all-services"
+                                }
+                            },
+                            "operations" => {
+                                "add" => {
+                                    "operation-name" => "add",
+                                    "description" => "Adds a socket binding configuration to the group.",
+                                    "request-properties" => {
+                                        "client-mappings" => {
+                                            "type" => LIST,
+                                            "description" => "Specifies zero or more client mappings for this socket binding. A client connecting to this socket should use the destination address specified in the mapping that matches its desired outbound interface. This allows for advanced network topologies that use either network address translation, or have bindings on multiple network interfaces to function. Each mapping should be evaluated in declared order, with the first successful match used to determine the destination.",
+                                            "expressions-allowed" => false,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 0L,
+                                            "max-length" => 2147483647L,
+                                            "value-type" => {
+                                                "source-network" => {
+                                                    "type" => STRING,
+                                                    "description" => "Source network the client connection binds on. This value is in the form of ip/netmask. A client should match this value against the desired client host network interface, and if matched the client should connect to the corresponding destination values. If omitted this mapping should match any interface.",
+                                                    "expressions-allowed" => true,
+                                                    "required" => false,
+                                                    "nillable" => true
+                                                },
+                                                "destination-address" => {
+                                                    "type" => STRING,
+                                                    "description" => "The destination address that a client should connect to if the source-network matches. This value can either be a hostname or an IP address.",
+                                                    "expressions-allowed" => true,
+                                                    "required" => true,
+                                                    "nillable" => false,
+                                                    "min-length" => 1L,
+                                                    "max-length" => 2147483647L
+                                                },
+                                                "destination-port" => {
+                                                    "type" => INT,
+                                                    "description" => "The destination port that a client should connect to if the source-network matches. If omitted this mapping will reuse the effective socket binding port.",
+                                                    "expressions-allowed" => true,
+                                                    "required" => false,
+                                                    "nillable" => true,
+                                                    "min" => 0L,
+                                                    "max" => 65535L
+                                                }
+                                            }
+                                        },
+                                        "fixed-port" => {
+                                            "type" => BOOLEAN,
+                                            "description" => "Whether the port value should remain fixed even if numeric offsets are applied to the other sockets in the socket group.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "default" => false
+                                        },
+                                        "interface" => {
+                                            "type" => STRING,
+                                            "description" => "Name of the interface to which the socket should be bound, or, for multicast sockets, the interface on which it should listen. This should be one of the declared interfaces.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "capability-reference" => "org.wildfly.network.interface",
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "multicast-address" => {
+                                            "type" => STRING,
+                                            "description" => "Multicast address on which the socket should receive multicast traffic. If unspecified, the socket will not be configured to receive multicast.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "multicast-port" => {
+                                            "type" => INT,
+                                            "description" => "Port on which the socket should receive multicast traffic. Must be configured if 'multicast-address' is configured.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min" => 1L,
+                                            "max" => 65535L
+                                        },
+                                        "port" => {
+                                            "type" => INT,
+                                            "description" => "Number of the port to which the socket should be bound.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "default" => 0,
+                                            "min" => 0L,
+                                            "max" => 65535L
+                                        }
+                                    },
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "restart-required" => "all-services",
+                                    "runtime-only" => false
+                                },
+                                "remove" => {
+                                    "operation-name" => "remove",
+                                    "description" => "Removes a socket binding configuration from the group.",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "restart-required" => "all-services",
+                                    "runtime-only" => false
+                                }
+                            },
+                            "notifications" => undefined,
+                            "children" => {}
+                        }}
+                    }
+                }
+            }}
+        },
+        "path" => {
+            "description" => "A list of named filesystem paths. The paths may or may not be fully specified (i.e. include the actual paths.)",
+            "model-description" => {"*" => {
+                "description" => "A named filesystem path, but without a requirement to specify the actual path. If no actual path is specified, acts as a placeholder in the model (e.g. at the domain level) until a fully specified path definition is applied at a lower level (e.g. at the host level, where available addresses are known.)",
+                "capabilities" => [{
+                    "name" => "org.wildfly.management.path",
+                    "dynamic" => true,
+                    "dynamic-elements" => ["path"]
+                }],
+                "attributes" => {
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The name of the path. Cannot be one of the standard fixed paths provided by the system: jboss.home - the root directory of the JBoss AS distribution; user.home - user's home directory; user.dir - user's current working directory; java.home - java installation directory; jboss.server.base.dir - root directory for an individual server instance. Note that the system provides other standard paths that can be overridden by declaring them in the configuration file. See the 'relative-to' attribute documentation for a complete list of standard paths.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-only",
+                        "storage" => "configuration"
+                    },
+                    "path" => {
+                        "type" => STRING,
+                        "description" => "The actual filesystem path. Treated as an absolute path, unless the 'relative-to' attribute is specified, in which case the value is treated as relative to that path. If treated as an absolute path, the actual runtime pathname specified by the value of this attribute will be determined as follows: If this value is already absolute, then the value is directly used.  Otherwise the runtime pathname is resolved in a system-dependent way.  On UNIX systems, a relative pathname is made absolute by resolving it against the current user directory. On Microsoft Windows systems, a relative pathname is made absolute by resolving it against the current directory of the drive named by the pathname, if any; if not, it is resolved against the current user directory.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "read-only" => {
+                        "type" => BOOLEAN,
+                        "description" => "True if added by the system, false if configured by user. If true, the path cannot be removed or modified.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "default" => false,
+                        "access-type" => "read-only",
+                        "storage" => "runtime"
+                    },
+                    "relative-to" => {
+                        "type" => STRING,
+                        "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include: jboss.home - the root directory of the JBoss AS distribution; user.home - user's home directory; user.dir - user's current working directory; java.home - java installation directory; jboss.server.base.dir - root directory for an individual server instance; jboss.server.data.dir - directory the server will use for persistent data file storage; jboss.server.log.dir - directory the server will use for log file storage; jboss.server.tmp.dir - directory the server will use for temporary file storage; jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "capability-reference" => "org.wildfly.management.path",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    }
+                },
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Add a new path.",
+                        "request-properties" => {
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "The actual filesystem path. Treated as an absolute path, unless the 'relative-to' attribute is specified, in which case the value is treated as relative to that path. If treated as an absolute path, the actual runtime pathname specified by the value of this attribute will be determined as follows: If this value is already absolute, then the value is directly used.  Otherwise the runtime pathname is resolved in a system-dependent way.  On UNIX systems, a relative pathname is made absolute by resolving it against the current user directory. On Microsoft Windows systems, a relative pathname is made absolute by resolving it against the current directory of the drive named by the pathname, if any; if not, it is resolved against the current user directory.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "relative-to" => {
+                                "type" => STRING,
+                                "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include: jboss.home - the root directory of the JBoss AS distribution; user.home - user's home directory; user.dir - user's current working directory; java.home - java installation directory; jboss.server.base.dir - root directory for an individual server instance; jboss.server.data.dir - directory the server will use for persistent data file storage; jboss.server.log.dir - directory the server will use for log file storage; jboss.server.tmp.dir - directory the server will use for temporary file storage; jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "capability-reference" => "org.wildfly.management.path",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Remove a path",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "restart-required" => "all-services",
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => {}
+            }}
+        },
+        "deployment-overlay" => {
+            "description" => "A list of deployment overlays available for use by the server",
+            "model-description" => {"*" => {
+                "description" => "A deployment overlay",
+                "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+                "attributes" => {},
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Adds a deployment overlay",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "redeploy-links" => {
+                        "operation-name" => "redeploy-links",
+                        "description" => "Redeploys the deployments affected by this overlay.",
+                        "request-properties" => {"deployments" => {
+                            "type" => LIST,
+                            "description" => "List of deployment runtime names to be redeployed. If this list is empty or 'undefined' then all affected deployments will be redeployed.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 0L,
+                            "max-length" => 2147483647L,
+                            "value-type" => STRING
+                        }},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Removes a deployment overlay",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "restart-required" => "all-services",
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => {"content" => {
+                    "description" => "The content of the deployment overlay",
+                    "model-description" => {"*" => {
+                        "description" => "The content of the deployment overlay",
+                        "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+                        "attributes" => {
+                            "content" => {
+                                "type" => BYTES,
+                                "description" => "The deployment overlay content item",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 20L,
+                                "max-length" => 20L,
+                                "access-type" => "read-only",
+                                "storage" => "configuration"
+                            },
+                            "stream" => {
+                                "type" => STRING,
+                                "description" => "Provides the overlay content file a response attachment. The response result value is the unique id of the attachment.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "access-type" => "read-only",
+                                "storage" => "runtime"
+                            }
+                        },
+                        "operations" => {
+                            "add" => {
+                                "operation-name" => "add",
+                                "description" => "Adds a deployment overlay",
+                                "request-properties" => {"content" => {
+                                    "type" => OBJECT,
+                                    "description" => "The content of the deployment overlay",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "value-type" => {
+                                        "input-stream-index" => {
+                                            "type" => INT,
+                                            "description" => "The index into the operation's attached input streams of the input stream that contains deployment content that should be uploaded to the domain's or standalone server's deployment content repository.",
+                                            "expressions-allowed" => false,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min" => 0L,
+                                            "max" => 2147483647L,
+                                            "filesystem-path" => true,
+                                            "attached-streams" => true
+                                        },
+                                        "hash" => {
+                                            "type" => BYTES,
+                                            "description" => "The content hash",
+                                            "expressions-allowed" => false,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 20L,
+                                            "max-length" => 20L
+                                        },
+                                        "bytes" => {
+                                            "type" => BYTES,
+                                            "description" => "Byte array containing the deployment content that should uploaded to the domain's or standalone server's deployment content repository.",
+                                            "expressions-allowed" => false,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "url" => {
+                                            "type" => STRING,
+                                            "description" => "The URL at which the deployment content is available for upload to the domain's or standalone server's deployment content repository. Note that the URL must be accessible from the target of the operation (i.e. the Domain Controller or standalone server).",
+                                            "expressions-allowed" => false,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        }
+                                    }
+                                }},
+                                "reply-properties" => {},
+                                "read-only" => false,
+                                "runtime-only" => false
+                            },
+                            "read-content" => {
+                                "operation-name" => "read-content",
+                                "description" => "Gets the content of the deployment overlay file.",
+                                "request-properties" => {},
+                                "reply-properties" => {},
+                                "deprecated" => {
+                                    "since" => "5.0.0",
+                                    "reason" => "Read the 'stream' attribute instead."
+                                },
+                                "read-only" => false,
+                                "runtime-only" => false
+                            },
+                            "remove" => {
+                                "operation-name" => "remove",
+                                "description" => "Removes a piece of content",
+                                "request-properties" => {},
+                                "reply-properties" => {},
+                                "read-only" => false,
+                                "restart-required" => "resource-services",
+                                "runtime-only" => false
+                            }
+                        },
+                        "notifications" => undefined,
+                        "children" => {}
+                    }}
+                }}
+            }}
+        },
+        "core-service" => {
+            "description" => "Configuration of core services provided by the managed domain hosts and servers.",
+            "model-description" => {"management" => {
+                "description" => "The management services used to control a server or a host's host controller.",
+                "attributes" => {},
+                "operations" => undefined,
+                "notifications" => undefined,
+                "children" => {
+                    "service" => {
+                        "description" => "Management services.",
+                        "model-description" => {"configuration-changes" => {
+                            "description" => "Service to store and list configuration changes.",
+                            "deprecated" => {
+                                "since" => "4.2.0",
+                                "reason" => "The configuration changes service at the root of a Domain Controller is deprecated and may be removed or moved in future versions."
+                            },
+                            "attributes" => {},
+                            "operations" => {"add" => {
+                                "operation-name" => "add",
+                                "description" => "Add the history for configuration changes.",
+                                "request-properties" => {},
+                                "reply-properties" => {},
+                                "read-only" => false,
+                                "runtime-only" => false
+                            }},
+                            "notifications" => undefined,
+                            "children" => {}
+                        }}
+                    },
+                    "host-connection" => {
+                        "description" => "Information about the connection state of a secondary host controller.",
+                        "model-description" => {"*" => {
+                            "description" => "Information about the connection state of a secondary host controller.",
+                            "attributes" => {
+                                "connected" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "Whether the host controller is connected or not.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "access-type" => "read-only",
+                                    "storage" => "runtime"
+                                },
+                                "events" => {
+                                    "type" => LIST,
+                                    "description" => "The secondary host events.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "min-length" => 0L,
+                                    "max-length" => 2147483647L,
+                                    "value-type" => {
+                                        "type" => {
+                                            "type" => STRING,
+                                            "description" => "The state of the host-controller connection.",
+                                            "expressions-allowed" => false,
+                                            "required" => true,
+                                            "nillable" => false,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "address" => {
+                                            "type" => STRING,
+                                            "description" => "The secondary host address if available.",
+                                            "expressions-allowed" => false,
+                                            "required" => true,
+                                            "nillable" => false,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "timestamp" => {
+                                            "type" => LONG,
+                                            "description" => "The time of the event.",
+                                            "expressions-allowed" => false,
+                                            "required" => true,
+                                            "nillable" => false
+                                        }
+                                    },
+                                    "access-type" => "read-only",
+                                    "storage" => "runtime"
+                                }
+                            },
+                            "operations" => {
+                                "prune-disconnected" => {
+                                    "operation-name" => "prune-disconnected",
+                                    "description" => "Prune information about all disconnected hosts.",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "prune-expired" => {
+                                    "operation-name" => "prune-expired",
+                                    "description" => "Prune the expired host event entries.",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                }
+                            },
+                            "notifications" => undefined,
+                            "children" => {}
+                        }}
+                    },
+                    "access" => {
+                        "description" => "Model representation for configuration affecting access control and auditing of access.",
+                        "model-description" => {"authorization" => {
+                            "description" => "The access control definitions defining the access management restrictions.",
+                            "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                            "attributes" => {
+                                "all-role-names" => {
+                                    "type" => LIST,
+                                    "description" => "The official names of all roles supported by the current management access control provider. This includes any standard roles as well as any user-defined roles.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "min-length" => 0L,
+                                    "max-length" => 2147483647L,
+                                    "value-type" => STRING,
+                                    "access-type" => "read-only",
+                                    "storage" => "runtime"
+                                },
+                                "permission-combination-policy" => {
+                                    "type" => STRING,
+                                    "description" => "The policy for combining access control permissions when the authorization policy grants the user more than one type of permission for a given action. In the standard role based authorization policy, this would occur when a user maps to multiple roles. The 'permissive' policy means if any of the permissions allow the action, the action is allowed. The 'rejecting' policy means the existence of multiple permissions should result in an error.",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => "permissive",
+                                    "allowed" => [
+                                        "permissive",
+                                        "rejecting"
+                                    ],
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "provider" => {
+                                    "type" => STRING,
+                                    "description" => "The provider to use for management access control decisions.",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => "simple",
+                                    "allowed" => [
+                                        "simple",
+                                        "rbac"
+                                    ],
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "standard-role-names" => {
+                                    "type" => LIST,
+                                    "description" => "The official names of the standard roles supported by the current management access control provider.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "min-length" => 0L,
+                                    "max-length" => 2147483647L,
+                                    "value-type" => STRING,
+                                    "access-type" => "read-only",
+                                    "storage" => "runtime"
+                                },
+                                "use-identity-roles" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "Should the raw roles obtained from the underlying security identity be used directly?",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => false,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                }
+                            },
+                            "operations" => undefined,
+                            "notifications" => undefined,
+                            "children" => {
+                                "role-mapping" => {
+                                    "description" => "A mapping of users and groups to a specific role.",
+                                    "model-description" => {"*" => {
+                                        "description" => "A mapping of users and groups to a specific role.",
+                                        "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                        "attributes" => {"include-all" => {
+                                            "type" => BOOLEAN,
+                                            "description" => "Configure if all authenticated users should be automatically assigned this role.",
+                                            "expressions-allowed" => false,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "default" => false,
+                                            "access-type" => "read-write",
+                                            "storage" => "configuration",
+                                            "restart-required" => "no-services"
+                                        }},
+                                        "operations" => {
+                                            "add" => {
+                                                "operation-name" => "add",
+                                                "description" => "Add a new role mapping definition.",
+                                                "request-properties" => {"include-all" => {
+                                                    "type" => BOOLEAN,
+                                                    "description" => "Configure if all authenticated users should be automatically assigned this role.",
+                                                    "expressions-allowed" => false,
+                                                    "required" => false,
+                                                    "nillable" => true,
+                                                    "default" => false
+                                                }},
+                                                "reply-properties" => {},
+                                                "read-only" => false,
+                                                "runtime-only" => false
+                                            },
+                                            "is-caller-in-role" => {
+                                                "operation-name" => "is-caller-in-role",
+                                                "description" => "Test if the current caller is a member of the role.",
+                                                "request-properties" => {},
+                                                "reply-properties" => {"type" => BOOLEAN},
+                                                "read-only" => true,
+                                                "runtime-only" => false
+                                            },
+                                            "remove" => {
+                                                "operation-name" => "remove",
+                                                "description" => "Remove an existing role mapping definition.",
+                                                "request-properties" => {},
+                                                "reply-properties" => {},
+                                                "read-only" => false,
+                                                "restart-required" => "resource-services",
+                                                "runtime-only" => false
+                                            }
+                                        },
+                                        "notifications" => undefined,
+                                        "children" => {
+                                            "include" => {
+                                                "description" => "Principals to be included in a role.",
+                                                "model-description" => {"*" => {
+                                                    "description" => "An individual principal used within a role mapping.",
+                                                    "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                                    "attributes" => {
+                                                        "name" => {
+                                                            "type" => STRING,
+                                                            "description" => "The name of the user or group being mapped.",
+                                                            "expressions-allowed" => false,
+                                                            "required" => true,
+                                                            "nillable" => false,
+                                                            "min-length" => 1L,
+                                                            "max-length" => 2147483647L,
+                                                            "access-type" => "read-only",
+                                                            "storage" => "configuration"
+                                                        },
+                                                        "realm" => {
+                                                            "type" => STRING,
+                                                            "description" => "An optional attribute to map based on the realm used for authentication.",
+                                                            "expressions-allowed" => false,
+                                                            "required" => false,
+                                                            "nillable" => true,
+                                                            "min-length" => 1L,
+                                                            "max-length" => 2147483647L,
+                                                            "deprecated" => {
+                                                                "since" => "5.0.0",
+                                                                "reason" => "This attribute is no longer used once management security is migrated to Elytron based security."
+                                                            },
+                                                            "access-type" => "read-only",
+                                                            "storage" => "configuration"
+                                                        },
+                                                        "type" => {
+                                                            "type" => STRING,
+                                                            "description" => "The type of the Principal being mapped, either 'group' or 'user'.",
+                                                            "expressions-allowed" => false,
+                                                            "required" => true,
+                                                            "nillable" => false,
+                                                            "allowed" => [
+                                                                "GROUP",
+                                                                "USER"
+                                                            ],
+                                                            "access-type" => "read-only",
+                                                            "storage" => "configuration"
+                                                        }
+                                                    },
+                                                    "operations" => {
+                                                        "add" => {
+                                                            "operation-name" => "add",
+                                                            "description" => "Add a new principal to role mapping.",
+                                                            "request-properties" => {
+                                                                "name" => {
+                                                                    "type" => STRING,
+                                                                    "description" => "The name of the user or group being mapped.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => true,
+                                                                    "nillable" => false,
+                                                                    "min-length" => 1L,
+                                                                    "max-length" => 2147483647L
+                                                                },
+                                                                "realm" => {
+                                                                    "type" => STRING,
+                                                                    "description" => "An optional attribute to map based on the realm used for authentication.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => false,
+                                                                    "nillable" => true,
+                                                                    "min-length" => 1L,
+                                                                    "max-length" => 2147483647L,
+                                                                    "deprecated" => {
+                                                                        "since" => "5.0.0",
+                                                                        "reason" => "This attribute is no longer used once management security is migrated to Elytron based security."
+                                                                    }
+                                                                },
+                                                                "type" => {
+                                                                    "type" => STRING,
+                                                                    "description" => "The type of the Principal being mapped, either 'group' or 'user'.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => true,
+                                                                    "nillable" => false,
+                                                                    "allowed" => [
+                                                                        "GROUP",
+                                                                        "USER"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "reply-properties" => {},
+                                                            "read-only" => false,
+                                                            "runtime-only" => false
+                                                        },
+                                                        "remove" => {
+                                                            "operation-name" => "remove",
+                                                            "description" => "Remove an existing principal to role mapping.",
+                                                            "request-properties" => {},
+                                                            "reply-properties" => {},
+                                                            "read-only" => false,
+                                                            "restart-required" => "resource-services",
+                                                            "runtime-only" => false
+                                                        }
+                                                    },
+                                                    "notifications" => undefined,
+                                                    "children" => {}
+                                                }}
+                                            },
+                                            "exclude" => {
+                                                "description" => "Principals to be excluded from a role.",
+                                                "model-description" => {"*" => {
+                                                    "description" => "An individual principal used within a role mapping.",
+                                                    "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                                    "attributes" => {
+                                                        "name" => {
+                                                            "type" => STRING,
+                                                            "description" => "The name of the user or group being mapped.",
+                                                            "expressions-allowed" => false,
+                                                            "required" => true,
+                                                            "nillable" => false,
+                                                            "min-length" => 1L,
+                                                            "max-length" => 2147483647L,
+                                                            "access-type" => "read-only",
+                                                            "storage" => "configuration"
+                                                        },
+                                                        "realm" => {
+                                                            "type" => STRING,
+                                                            "description" => "An optional attribute to map based on the realm used for authentication.",
+                                                            "expressions-allowed" => false,
+                                                            "required" => false,
+                                                            "nillable" => true,
+                                                            "min-length" => 1L,
+                                                            "max-length" => 2147483647L,
+                                                            "deprecated" => {
+                                                                "since" => "5.0.0",
+                                                                "reason" => "This attribute is no longer used once management security is migrated to Elytron based security."
+                                                            },
+                                                            "access-type" => "read-only",
+                                                            "storage" => "configuration"
+                                                        },
+                                                        "type" => {
+                                                            "type" => STRING,
+                                                            "description" => "The type of the Principal being mapped, either 'group' or 'user'.",
+                                                            "expressions-allowed" => false,
+                                                            "required" => true,
+                                                            "nillable" => false,
+                                                            "allowed" => [
+                                                                "GROUP",
+                                                                "USER"
+                                                            ],
+                                                            "access-type" => "read-only",
+                                                            "storage" => "configuration"
+                                                        }
+                                                    },
+                                                    "operations" => {
+                                                        "add" => {
+                                                            "operation-name" => "add",
+                                                            "description" => "Add a new principal to role mapping.",
+                                                            "request-properties" => {
+                                                                "name" => {
+                                                                    "type" => STRING,
+                                                                    "description" => "The name of the user or group being mapped.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => true,
+                                                                    "nillable" => false,
+                                                                    "min-length" => 1L,
+                                                                    "max-length" => 2147483647L
+                                                                },
+                                                                "realm" => {
+                                                                    "type" => STRING,
+                                                                    "description" => "An optional attribute to map based on the realm used for authentication.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => false,
+                                                                    "nillable" => true,
+                                                                    "min-length" => 1L,
+                                                                    "max-length" => 2147483647L,
+                                                                    "deprecated" => {
+                                                                        "since" => "5.0.0",
+                                                                        "reason" => "This attribute is no longer used once management security is migrated to Elytron based security."
+                                                                    }
+                                                                },
+                                                                "type" => {
+                                                                    "type" => STRING,
+                                                                    "description" => "The type of the Principal being mapped, either 'group' or 'user'.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => true,
+                                                                    "nillable" => false,
+                                                                    "allowed" => [
+                                                                        "GROUP",
+                                                                        "USER"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "reply-properties" => {},
+                                                            "read-only" => false,
+                                                            "runtime-only" => false
+                                                        },
+                                                        "remove" => {
+                                                            "operation-name" => "remove",
+                                                            "description" => "Remove an existing principal to role mapping.",
+                                                            "request-properties" => {},
+                                                            "reply-properties" => {},
+                                                            "read-only" => false,
+                                                            "restart-required" => "resource-services",
+                                                            "runtime-only" => false
+                                                        }
+                                                    },
+                                                    "notifications" => undefined,
+                                                    "children" => {}
+                                                }}
+                                            }
+                                        }
+                                    }}
+                                },
+                                "constraint" => {
+                                    "description" => "Access constraints for the vault expressions sensitivity, sensitivity classifications and the application resources.",
+                                    "model-description" => {
+                                        "application-classification" => {
+                                            "description" => "Configuration of the application classification constraints.",
+                                            "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                            "attributes" => {},
+                                            "operations" => undefined,
+                                            "notifications" => undefined,
+                                            "children" => {"type" => {
+                                                "description" => "The named application classifications grouped by the constraint's subsystem, or 'core' if it comes from the core model.",
+                                                "model-description" => {"*" => {
+                                                    "description" => "The application classification constraints by type. Type is either 'core' or the name of a subsystem.",
+                                                    "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                                    "attributes" => {},
+                                                    "operations" => undefined,
+                                                    "notifications" => undefined,
+                                                    "children" => {"classification" => {
+                                                        "description" => "The application classification constraints by type.",
+                                                        "model-description" => {"*" => {
+                                                            "description" => "Configuration of an application classification constraint.",
+                                                            "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                                            "attributes" => {
+                                                                "configured-application" => {
+                                                                    "type" => BOOLEAN,
+                                                                    "description" => "Set to override the default as to whether the constraint is considered an application resource.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => false,
+                                                                    "nillable" => true,
+                                                                    "access-type" => "read-write",
+                                                                    "storage" => "configuration",
+                                                                    "restart-required" => "no-services"
+                                                                },
+                                                                "default-application" => {
+                                                                    "type" => BOOLEAN,
+                                                                    "description" => "Whether targets having this application type constraint are considered application resources.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => true,
+                                                                    "nillable" => false,
+                                                                    "access-type" => "read-only",
+                                                                    "storage" => "runtime"
+                                                                }
+                                                            },
+                                                            "operations" => undefined,
+                                                            "notifications" => undefined,
+                                                            "children" => {"applies-to" => {
+                                                                "description" => "Information about the resources, attributes and operations to which this application classification constraint applies.",
+                                                                "model-description" => {"*" => {
+                                                                    "description" => "Information about the resources, attributes and operations to which an access control constraint applies.",
+                                                                    "storage" => "runtime-only",
+                                                                    "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                                                    "attributes" => {
+                                                                        "address" => {
+                                                                            "type" => STRING,
+                                                                            "description" => "Address pattern describing a resource or resources to which the constraint applies.",
+                                                                            "expressions-allowed" => false,
+                                                                            "required" => true,
+                                                                            "nillable" => false,
+                                                                            "min-length" => 1L,
+                                                                            "max-length" => 2147483647L,
+                                                                            "access-type" => "read-only",
+                                                                            "storage" => "configuration"
+                                                                        },
+                                                                        "attributes" => {
+                                                                            "type" => LIST,
+                                                                            "description" => "List of the names of attributes to which the constraint specifically applies.",
+                                                                            "expressions-allowed" => false,
+                                                                            "required" => true,
+                                                                            "nillable" => false,
+                                                                            "min-length" => 0L,
+                                                                            "max-length" => 2147483647L,
+                                                                            "value-type" => STRING,
+                                                                            "access-type" => "read-only",
+                                                                            "storage" => "configuration"
+                                                                        },
+                                                                        "entire-resource" => {
+                                                                            "type" => BOOLEAN,
+                                                                            "description" => "True if the constraint applies to the resource as a whole; false if it only applies to one or more attributes or operations.",
+                                                                            "expressions-allowed" => false,
+                                                                            "required" => true,
+                                                                            "nillable" => false,
+                                                                            "access-type" => "read-only",
+                                                                            "storage" => "configuration"
+                                                                        },
+                                                                        "operations" => {
+                                                                            "type" => LIST,
+                                                                            "description" => "List of the names of operations to which the constraint specifically applies.",
+                                                                            "expressions-allowed" => false,
+                                                                            "required" => true,
+                                                                            "nillable" => false,
+                                                                            "min-length" => 0L,
+                                                                            "max-length" => 2147483647L,
+                                                                            "value-type" => STRING,
+                                                                            "access-type" => "read-only",
+                                                                            "storage" => "configuration"
+                                                                        }
+                                                                    },
+                                                                    "operations" => undefined,
+                                                                    "notifications" => undefined,
+                                                                    "children" => {}
+                                                                }}
+                                                            }}
+                                                        }}
+                                                    }}
+                                                }}
+                                            }}
+                                        },
+                                        "sensitivity-classification" => {
+                                            "description" => "The sensitivity classification constraints.",
+                                            "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                            "attributes" => {},
+                                            "operations" => undefined,
+                                            "notifications" => undefined,
+                                            "children" => {"type" => {
+                                                "description" => "The named application classifications grouped by the constraint's subsystem, or 'core' if it comes from the core model.",
+                                                "model-description" => {"*" => {
+                                                    "description" => "The sensitivity classifications by type. Type is either 'core' or the name of a subsystem.",
+                                                    "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                                    "attributes" => {},
+                                                    "operations" => undefined,
+                                                    "notifications" => undefined,
+                                                    "children" => {"classification" => {
+                                                        "description" => "The sensitivity classifications by type",
+                                                        "model-description" => {"*" => {
+                                                            "description" => "Configuration of a sensitivity constraint.",
+                                                            "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                                            "attributes" => {
+                                                                "configured-requires-addressable" => {
+                                                                    "type" => BOOLEAN,
+                                                                    "description" => "Set to override the default as to whether the visibility of resources annotated with this sensitivity constraint should be considered sensitive.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => false,
+                                                                    "nillable" => true,
+                                                                    "access-type" => "read-write",
+                                                                    "storage" => "configuration",
+                                                                    "restart-required" => "no-services"
+                                                                },
+                                                                "configured-requires-read" => {
+                                                                    "type" => BOOLEAN,
+                                                                    "description" => "Set to override the default as to whether reading attributes annotated with this sensitivity constraint should be considered sensitive.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => false,
+                                                                    "nillable" => true,
+                                                                    "access-type" => "read-write",
+                                                                    "storage" => "configuration",
+                                                                    "restart-required" => "no-services"
+                                                                },
+                                                                "configured-requires-write" => {
+                                                                    "type" => BOOLEAN,
+                                                                    "description" => "Set to override the default as to whether writing attributes annotated with this sensitivity constraint should be considered sensitive.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => false,
+                                                                    "nillable" => true,
+                                                                    "access-type" => "read-write",
+                                                                    "storage" => "configuration",
+                                                                    "restart-required" => "no-services"
+                                                                },
+                                                                "default-requires-addressable" => {
+                                                                    "type" => BOOLEAN,
+                                                                    "description" => "Whether the visibility of resources annotated with this sensitivity constraint should be considered sensitive.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => true,
+                                                                    "nillable" => false,
+                                                                    "access-type" => "read-only",
+                                                                    "storage" => "runtime"
+                                                                },
+                                                                "default-requires-read" => {
+                                                                    "type" => BOOLEAN,
+                                                                    "description" => "Whether reading attributes annotated with this sensitivity constraint should be considered sensitive.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => true,
+                                                                    "nillable" => false,
+                                                                    "access-type" => "read-only",
+                                                                    "storage" => "runtime"
+                                                                },
+                                                                "default-requires-write" => {
+                                                                    "type" => BOOLEAN,
+                                                                    "description" => "Whether writing attributes annotated with this sensitivity constraint should be considered sensitive.",
+                                                                    "expressions-allowed" => false,
+                                                                    "required" => true,
+                                                                    "nillable" => false,
+                                                                    "access-type" => "read-only",
+                                                                    "storage" => "runtime"
+                                                                }
+                                                            },
+                                                            "operations" => undefined,
+                                                            "notifications" => undefined,
+                                                            "children" => {"applies-to" => {
+                                                                "description" => "Information about the resources, attributes and operations to which this sensitivity classification constraint applies.",
+                                                                "model-description" => {"*" => {
+                                                                    "description" => "Information about the resources, attributes and operations to which an access control constraint applies.",
+                                                                    "storage" => "runtime-only",
+                                                                    "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                                                    "attributes" => {
+                                                                        "address" => {
+                                                                            "type" => STRING,
+                                                                            "description" => "Address pattern describing a resource or resources to which the constraint applies.",
+                                                                            "expressions-allowed" => false,
+                                                                            "required" => true,
+                                                                            "nillable" => false,
+                                                                            "min-length" => 1L,
+                                                                            "max-length" => 2147483647L,
+                                                                            "access-type" => "read-only",
+                                                                            "storage" => "configuration"
+                                                                        },
+                                                                        "attributes" => {
+                                                                            "type" => LIST,
+                                                                            "description" => "List of the names of attributes to which the constraint specifically applies.",
+                                                                            "expressions-allowed" => false,
+                                                                            "required" => true,
+                                                                            "nillable" => false,
+                                                                            "min-length" => 0L,
+                                                                            "max-length" => 2147483647L,
+                                                                            "value-type" => STRING,
+                                                                            "access-type" => "read-only",
+                                                                            "storage" => "configuration"
+                                                                        },
+                                                                        "entire-resource" => {
+                                                                            "type" => BOOLEAN,
+                                                                            "description" => "True if the constraint applies to the resource as a whole; false if it only applies to one or more attributes or operations.",
+                                                                            "expressions-allowed" => false,
+                                                                            "required" => true,
+                                                                            "nillable" => false,
+                                                                            "access-type" => "read-only",
+                                                                            "storage" => "configuration"
+                                                                        },
+                                                                        "operations" => {
+                                                                            "type" => LIST,
+                                                                            "description" => "List of the names of operations to which the constraint specifically applies.",
+                                                                            "expressions-allowed" => false,
+                                                                            "required" => true,
+                                                                            "nillable" => false,
+                                                                            "min-length" => 0L,
+                                                                            "max-length" => 2147483647L,
+                                                                            "value-type" => STRING,
+                                                                            "access-type" => "read-only",
+                                                                            "storage" => "configuration"
+                                                                        }
+                                                                    },
+                                                                    "operations" => undefined,
+                                                                    "notifications" => undefined,
+                                                                    "children" => {}
+                                                                }}
+                                                            }}
+                                                        }}
+                                                    }}
+                                                }}
+                                            }}
+                                        },
+                                        "vault-expression" => {
+                                            "description" => "Configuration of whether vault expressions should be considered sensitive.",
+                                            "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                            "attributes" => {
+                                                "configured-requires-read" => {
+                                                    "type" => BOOLEAN,
+                                                    "description" => "Set to override the default as to whether reading attributes containing vault expressions should be considered sensitive.",
+                                                    "expressions-allowed" => false,
+                                                    "required" => false,
+                                                    "nillable" => true,
+                                                    "access-type" => "read-write",
+                                                    "storage" => "configuration",
+                                                    "restart-required" => "no-services"
+                                                },
+                                                "configured-requires-write" => {
+                                                    "type" => BOOLEAN,
+                                                    "description" => "Set to override the default as to whether writing attributes containing vault expressions should be considered sensitive.",
+                                                    "expressions-allowed" => false,
+                                                    "required" => false,
+                                                    "nillable" => true,
+                                                    "access-type" => "read-write",
+                                                    "storage" => "configuration",
+                                                    "restart-required" => "no-services"
+                                                },
+                                                "default-requires-read" => {
+                                                    "type" => BOOLEAN,
+                                                    "description" => "Whether reading attributes containing vault expressions should be considered sensitive.",
+                                                    "expressions-allowed" => false,
+                                                    "required" => true,
+                                                    "nillable" => false,
+                                                    "access-type" => "read-only",
+                                                    "storage" => "runtime"
+                                                },
+                                                "default-requires-write" => {
+                                                    "type" => BOOLEAN,
+                                                    "description" => "Whether writing attributes containing vault expressions should be considered sensitive.",
+                                                    "expressions-allowed" => false,
+                                                    "required" => true,
+                                                    "nillable" => false,
+                                                    "access-type" => "read-only",
+                                                    "storage" => "runtime"
+                                                }
+                                            },
+                                            "operations" => undefined,
+                                            "notifications" => undefined,
+                                            "children" => {}
+                                        }
+                                    }
+                                },
+                                "server-group-scoped-role" => {
+                                    "description" => "Administrative roles that are based on standard roles but are constrained to a particular set of managed domain server groups",
+                                    "model-description" => {"*" => {
+                                        "description" => "Administrative roles that are based on standard roles but are constrained to a particular set of managed domain server groups",
+                                        "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                        "attributes" => {
+                                            "base-role" => {
+                                                "type" => STRING,
+                                                "description" => "The standard role upon which the server-group-scoped-role is based",
+                                                "expressions-allowed" => false,
+                                                "required" => true,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L,
+                                                "access-type" => "read-write",
+                                                "storage" => "configuration",
+                                                "restart-required" => "all-services"
+                                            },
+                                            "server-groups" => {
+                                                "type" => LIST,
+                                                "description" => "The list of names server groups to which this users in this role are constrained",
+                                                "expressions-allowed" => false,
+                                                "required" => true,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L,
+                                                "value-type" => STRING,
+                                                "access-type" => "read-write",
+                                                "storage" => "configuration",
+                                                "restart-required" => "no-services"
+                                            }
+                                        },
+                                        "operations" => {
+                                            "add" => {
+                                                "operation-name" => "add",
+                                                "description" => "Adds a new server-group-scoped-role",
+                                                "request-properties" => {
+                                                    "base-role" => {
+                                                        "type" => STRING,
+                                                        "description" => "The standard role upon which the server-group-scoped-role is based",
+                                                        "expressions-allowed" => false,
+                                                        "required" => true,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "server-groups" => {
+                                                        "type" => LIST,
+                                                        "description" => "The list of names server groups to which this users in this role are constrained",
+                                                        "expressions-allowed" => false,
+                                                        "required" => true,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L,
+                                                        "value-type" => STRING
+                                                    }
+                                                },
+                                                "reply-properties" => {},
+                                                "read-only" => false,
+                                                "runtime-only" => false
+                                            },
+                                            "remove" => {
+                                                "operation-name" => "remove",
+                                                "description" => "Removes a server-group-scoped-role",
+                                                "request-properties" => {},
+                                                "reply-properties" => {},
+                                                "read-only" => false,
+                                                "runtime-only" => false
+                                            }
+                                        },
+                                        "notifications" => undefined,
+                                        "children" => {}
+                                    }}
+                                },
+                                "host-scoped-role" => {
+                                    "description" => "Administrative roles that are based on standard roles but are constrained to a particular set of managed domain hosts",
+                                    "model-description" => {"*" => {
+                                        "description" => "Administrative roles that are based on standard roles but are constrained to a particular set of managed domain hosts",
+                                        "access-constraints" => {"sensitive" => {"access-control" => {"type" => "core"}}},
+                                        "attributes" => {
+                                            "base-role" => {
+                                                "type" => STRING,
+                                                "description" => "The standard role upon which the host-scoped-role is based",
+                                                "expressions-allowed" => false,
+                                                "required" => true,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L,
+                                                "access-type" => "read-write",
+                                                "storage" => "configuration",
+                                                "restart-required" => "all-services"
+                                            },
+                                            "hosts" => {
+                                                "type" => LIST,
+                                                "description" => "The list of names hosts to which this users in this role are constrained",
+                                                "expressions-allowed" => false,
+                                                "required" => false,
+                                                "nillable" => true,
+                                                "min-length" => 0L,
+                                                "max-length" => 2147483647L,
+                                                "value-type" => STRING,
+                                                "access-type" => "read-write",
+                                                "storage" => "configuration",
+                                                "restart-required" => "no-services"
+                                            }
+                                        },
+                                        "operations" => {
+                                            "add" => {
+                                                "operation-name" => "add",
+                                                "description" => "Adds a new host-scoped-role",
+                                                "request-properties" => {
+                                                    "base-role" => {
+                                                        "type" => STRING,
+                                                        "description" => "The standard role upon which the host-scoped-role is based",
+                                                        "expressions-allowed" => false,
+                                                        "required" => true,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "hosts" => {
+                                                        "type" => LIST,
+                                                        "description" => "The list of names hosts to which this users in this role are constrained",
+                                                        "expressions-allowed" => false,
+                                                        "required" => false,
+                                                        "nillable" => true,
+                                                        "min-length" => 0L,
+                                                        "max-length" => 2147483647L,
+                                                        "value-type" => STRING
+                                                    }
+                                                },
+                                                "reply-properties" => {},
+                                                "read-only" => false,
+                                                "runtime-only" => false
+                                            },
+                                            "remove" => {
+                                                "operation-name" => "remove",
+                                                "description" => "Removes a host-scoped-role",
+                                                "request-properties" => {},
+                                                "reply-properties" => {},
+                                                "read-only" => false,
+                                                "runtime-only" => false
+                                            }
+                                        },
+                                        "notifications" => undefined,
+                                        "children" => {}
+                                    }}
+                                }
+                            }
+                        }}
+                    }
+                }
+            }}
+        },
+        "host-exclude" => {
+            "description" => "A list of configurations of resources that should be hidden by the Domain Controller from certain secondary Host Controllers.",
+            "model-description" => {"*" => {
+                "description" => "Configuration of resources that should be hidden by the Domain Controller from a secondary Host Controller that is running a particular version.",
+                "attributes" => {
+                    "active-server-groups" => {
+                        "type" => LIST,
+                        "description" => "A list of server group names the resources associated with which should be hidden from the target hosts. These are the groups used by the host's servers. The server-group and related profile, socket-binding-group and deployment resources will not be hidden; all others will be hidden.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "min-length" => 0L,
+                        "max-length" => 2147483647L,
+                        "value-type" => STRING,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "active-socket-binding-groups" => {
+                        "type" => LIST,
+                        "description" => "A list of socket-binding-group names specifying all the socket binding groups that are used by servers running on the target hosts. Only used if 'active-server-groups' is set;  otherwise ignored. Only needs to be set if the socket binding groups specified in the configuration of the server groups listed in 'active-server-groups' isn't the complete set of socket binding groups used on the servers (i.e. some other socket binding groups are specified in the target hosts' 'server-config' resources.)",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "min-length" => 0L,
+                        "max-length" => 2147483647L,
+                        "value-type" => STRING,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "excluded-extensions" => {
+                        "type" => LIST,
+                        "description" => "A list of extension names the resources for which (/extension=X) should be hidden from the target hosts.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "min-length" => 0L,
+                        "max-length" => 2147483647L,
+                        "value-type" => STRING,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "host-release" => {
+                        "type" => STRING,
+                        "description" => "A shorthand identifier for a well known EAP or WildFly Core based software distribution that a secondary Host Controller is running that should be affected by this configuration. Used as a simpler alternative to specifying the kernel management API versions.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => true,
+                        "alternatives" => ["management-major-version"],
+                        "allowed" => [
+                            "EAP6.2",
+                            "EAP6.3",
+                            "EAP6.4",
+                            "EAP7.0",
+                            "EAP7.1",
+                            "EAP7.2",
+                            "EAP7.3",
+                            "EAP7.4",
+                            "WildFly10.0",
+                            "WildFly10.1",
+                            "WildFly11.0",
+                            "WildFly12.0",
+                            "WildFly13.0",
+                            "WildFly14.0",
+                            "WildFly15.0",
+                            "WildFly16.0",
+                            "WildFly17.0",
+                            "WildFly18.0",
+                            "WildFly19.0",
+                            "WildFly20.0",
+                            "WildFly21.0",
+                            "WildFly22.0",
+                            "WildFly23.0",
+                            "WildFly24.0",
+                            "WildFly25.0",
+                            "WildFly26.0",
+                            "WildFly27.0",
+                            "WildFly28.0"
+                        ],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "management-major-version" => {
+                        "type" => INT,
+                        "description" => "The major version of the kernel management API that is supported by secondary hosts that should be affected by this configuration.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => true,
+                        "alternatives" => ["host-release"],
+                        "requires" => ["management-minor-version"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "management-micro-version" => {
+                        "type" => INT,
+                        "description" => "The micro version of the kernel management API that is supported by secondary hosts that should be affected by this configuration. If not defined, this configuration applies to all releases of the given major/minor version, excluding any for which a different configuration with a micro version also specified is present.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["host-release"],
+                        "requires" => [
+                            "management-major-version",
+                            "management-minor-version"
+                        ],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "management-minor-version" => {
+                        "type" => INT,
+                        "description" => "The minor version of the kernel management API that is supported by secondary hosts that should be affected by this configuration.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["host-release"],
+                        "requires" => ["management-major-version"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    }
+                },
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Adds a host-ignore configuration. The add does not affect any currently register hosts.",
+                        "request-properties" => {
+                            "active-server-groups" => {
+                                "type" => LIST,
+                                "description" => "A list of server group names the resources associated with which should be hidden from the target hosts. These are the groups used by the host's servers. The server-group and related profile, socket-binding-group and deployment resources will not be hidden; all others will be hidden.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "active-socket-binding-groups" => {
+                                "type" => LIST,
+                                "description" => "A list of socket-binding-group names specifying all the socket binding groups that are used by servers running on the target hosts. Only used if 'active-server-groups' is set;  otherwise ignored. Only needs to be set if the socket binding groups specified in the configuration of the server groups listed in 'active-server-groups' isn't the complete set of socket binding groups used on the servers (i.e. some other socket binding groups are specified in the target hosts' 'server-config' resources.)",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "excluded-extensions" => {
+                                "type" => LIST,
+                                "description" => "A list of extension names the resources for which (/extension=X) should be hidden from the target hosts.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "host-release" => {
+                                "type" => STRING,
+                                "description" => "A shorthand identifier for a well known EAP or WildFly Core based software distribution that a secondary Host Controller is running that should be affected by this configuration. Used as a simpler alternative to specifying the kernel management API versions.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => true,
+                                "alternatives" => ["management-major-version"],
+                                "allowed" => [
+                                    "EAP6.2",
+                                    "EAP6.3",
+                                    "EAP6.4",
+                                    "EAP7.0",
+                                    "EAP7.1",
+                                    "EAP7.2",
+                                    "EAP7.3",
+                                    "EAP7.4",
+                                    "WildFly10.0",
+                                    "WildFly10.1",
+                                    "WildFly11.0",
+                                    "WildFly12.0",
+                                    "WildFly13.0",
+                                    "WildFly14.0",
+                                    "WildFly15.0",
+                                    "WildFly16.0",
+                                    "WildFly17.0",
+                                    "WildFly18.0",
+                                    "WildFly19.0",
+                                    "WildFly20.0",
+                                    "WildFly21.0",
+                                    "WildFly22.0",
+                                    "WildFly23.0",
+                                    "WildFly24.0",
+                                    "WildFly25.0",
+                                    "WildFly26.0",
+                                    "WildFly27.0",
+                                    "WildFly28.0"
+                                ]
+                            },
+                            "management-major-version" => {
+                                "type" => INT,
+                                "description" => "The major version of the kernel management API that is supported by secondary hosts that should be affected by this configuration.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => true,
+                                "alternatives" => ["host-release"],
+                                "requires" => ["management-minor-version"]
+                            },
+                            "management-micro-version" => {
+                                "type" => INT,
+                                "description" => "The micro version of the kernel management API that is supported by secondary hosts that should be affected by this configuration. If not defined, this configuration applies to all releases of the given major/minor version, excluding any for which a different configuration with a micro version also specified is present.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["host-release"],
+                                "requires" => [
+                                    "management-major-version",
+                                    "management-minor-version"
+                                ]
+                            },
+                            "management-minor-version" => {
+                                "type" => INT,
+                                "description" => "The minor version of the kernel management API that is supported by secondary hosts that should be affected by this configuration.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["host-release"],
+                                "requires" => ["management-major-version"]
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Removes a host-ignore configuration. The remove does not affect any currently register hosts.",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "restart-required" => "resource-services",
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => {}
+            }}
+        },
+        "interface" => {
+            "description" => "A list of named network interfaces available for use in the domain. The interfaces may or may not be fully specified (i.e. include criteria on how to determine their IP address.",
+            "model-description" => {"*" => {
+                "description" => "Interface definition",
+                "capabilities" => [{
+                    "name" => "org.wildfly.network.interface",
+                    "dynamic" => true,
+                    "dynamic-elements" => ["interface"]
+                }],
+                "access-constraints" => {"sensitive" => {"socket-config" => {"type" => "core"}}},
+                "attributes" => {
+                    "any" => {
+                        "type" => OBJECT,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be that the IP address meets at least one of a nested set of criteria, but not necessarily all of the nested criteria. The value of the attribute is a set of criteria. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "value-type" => {
+                            "inet-address" => {
+                                "type" => LIST,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address matches the given value. Value is either an IP address in IPv6 or IPv4 dotted decimal notation, or a hostname that can be resolved to an IP address. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "link-local-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address is link-local. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "loopback" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a loopback address.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "loopback-address" => {
+                                "type" => STRING,
+                                "description" => "Attribute indicating that the IP address for this interface should be the given value, if a loopback interface exists on the machine. A 'loopback address' may not actually be configured on the machine's loopback interface. Differs from inet-address in that the given value will be used even if no NIC can be found that has the IP specified address associated with it. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "multicast" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface supports multicast.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "nic" => {
+                                "type" => LIST,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has the given name. The name of a network interface (e.g. eth0, eth1, lo). An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "nic-match" => {
+                                "type" => LIST,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has a name that matches the given regular expression. Value is a regular expression against which the names of the network interfaces available on the machine can be matched to find an acceptable interface. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "point-to-point" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface is a point-to-point interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "public-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a publicly routable address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "site-local-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it is a site-local address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "subnet-match" => {
+                                "type" => LIST,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it the address fits in the given subnet definition. Value is a network IP address and the number of bits in the address' network prefix, written in \"slash notation\"; e.g. \"192.168.0.0/16\". An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "up" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is currently up. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "virtual" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is a virtual interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            }
+                        },
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "any-address" => {
+                        "type" => BOOLEAN,
+                        "description" => "Attribute indicating that sockets using this interface should be bound to a wildcard address. The IPv6 wildcard address (::) will be used unless the java.net.preferIpV4Stack system property is set to true, in which case the IPv4 wildcard address (0.0.0.0) will be used. If a socket is bound to an IPv6 anylocal address on a dual-stack machine, it can accept both IPv6 and IPv4 traffic; if it is bound to an IPv4 (IPv4-mapped) anylocal address, it can only accept IPv4 traffic.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => [
+                            "inet-address",
+                            "link-local-address",
+                            "loopback",
+                            "loopback-address",
+                            "multicast",
+                            "nic",
+                            "nic-match",
+                            "point-to-point",
+                            "public-address",
+                            "site-local-address",
+                            "subnet-match",
+                            "up",
+                            "virtual",
+                            "any",
+                            "not"
+                        ],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "inet-address" => {
+                        "type" => STRING,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address matches the given value. Value is either an IP address in IPv6 or IPv4 dotted decimal notation, or a hostname that can be resolved to an IP address. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "link-local-address" => {
+                        "type" => BOOLEAN,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address is link-local. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "loopback" => {
+                        "type" => BOOLEAN,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a loopback address.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "loopback-address" => {
+                        "type" => STRING,
+                        "description" => "Attribute indicating that the IP address for this interface should be the given value, if a loopback interface exists on the machine. A 'loopback address' may not actually be configured on the machine's loopback interface. Differs from inet-address in that the given value will be used even if no NIC can be found that has the IP specified address associated with it. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "multicast" => {
+                        "type" => BOOLEAN,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface supports multicast.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The name of the interface.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-only",
+                        "storage" => "configuration"
+                    },
+                    "nic" => {
+                        "type" => STRING,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has the given name. The name of a network interface (e.g. eth0, eth1, lo). An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "nic-match" => {
+                        "type" => STRING,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has a name that matches the given regular expression. Value is a regular expression against which the names of the network interfaces available on the machine can be matched to find an acceptable interface. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "not" => {
+                        "type" => OBJECT,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be that the IP address *does not* meet any of a nested set of criteria. The value of the attribute is a set of criteria (e.g. 'loopback') whose normal meaning is reversed. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "value-type" => {
+                            "inet-address" => {
+                                "type" => LIST,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address matches the given value. Value is either an IP address in IPv6 or IPv4 dotted decimal notation, or a hostname that can be resolved to an IP address. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "link-local-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address is link-local. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "loopback" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a loopback address.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "loopback-address" => {
+                                "type" => STRING,
+                                "description" => "Attribute indicating that the IP address for this interface should be the given value, if a loopback interface exists on the machine. A 'loopback address' may not actually be configured on the machine's loopback interface. Differs from inet-address in that the given value will be used even if no NIC can be found that has the IP specified address associated with it. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "multicast" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface supports multicast.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "nic" => {
+                                "type" => LIST,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has the given name. The name of a network interface (e.g. eth0, eth1, lo). An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "nic-match" => {
+                                "type" => LIST,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has a name that matches the given regular expression. Value is a regular expression against which the names of the network interfaces available on the machine can be matched to find an acceptable interface. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "point-to-point" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface is a point-to-point interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "public-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a publicly routable address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "site-local-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it is a site-local address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "subnet-match" => {
+                                "type" => LIST,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it the address fits in the given subnet definition. Value is a network IP address and the number of bits in the address' network prefix, written in \"slash notation\"; e.g. \"192.168.0.0/16\". An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING
+                            },
+                            "up" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is currently up. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            },
+                            "virtual" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is a virtual interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true
+                            }
+                        },
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "point-to-point" => {
+                        "type" => BOOLEAN,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface is a point-to-point interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "public-address" => {
+                        "type" => BOOLEAN,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a publicly routable address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "site-local-address" => {
+                        "type" => BOOLEAN,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it is a site-local address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "subnet-match" => {
+                        "type" => STRING,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it the address fits in the given subnet definition. Value is a network IP address and the number of bits in the address' network prefix, written in \"slash notation\"; e.g. \"192.168.0.0/16\". An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "up" => {
+                        "type" => BOOLEAN,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is currently up. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    },
+                    "virtual" => {
+                        "type" => BOOLEAN,
+                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is a virtual interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "alternatives" => ["any-address"],
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "all-services"
+                    }
+                },
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Add a new interface specification.",
+                        "request-properties" => {
+                            "any" => {
+                                "type" => OBJECT,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be that the IP address meets at least one of a nested set of criteria, but not necessarily all of the nested criteria. The value of the attribute is a set of criteria. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"],
+                                "value-type" => {
+                                    "inet-address" => {
+                                        "type" => LIST,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address matches the given value. Value is either an IP address in IPv6 or IPv4 dotted decimal notation, or a hostname that can be resolved to an IP address. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 0L,
+                                        "max-length" => 2147483647L,
+                                        "value-type" => STRING
+                                    },
+                                    "link-local-address" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address is link-local. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "loopback" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a loopback address.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "loopback-address" => {
+                                        "type" => STRING,
+                                        "description" => "Attribute indicating that the IP address for this interface should be the given value, if a loopback interface exists on the machine. A 'loopback address' may not actually be configured on the machine's loopback interface. Differs from inet-address in that the given value will be used even if no NIC can be found that has the IP specified address associated with it. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => true,
+                                        "required" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "multicast" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface supports multicast.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "nic" => {
+                                        "type" => LIST,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has the given name. The name of a network interface (e.g. eth0, eth1, lo). An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 0L,
+                                        "max-length" => 2147483647L,
+                                        "value-type" => STRING
+                                    },
+                                    "nic-match" => {
+                                        "type" => LIST,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has a name that matches the given regular expression. Value is a regular expression against which the names of the network interfaces available on the machine can be matched to find an acceptable interface. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 0L,
+                                        "max-length" => 2147483647L,
+                                        "value-type" => STRING
+                                    },
+                                    "point-to-point" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface is a point-to-point interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "public-address" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a publicly routable address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "site-local-address" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it is a site-local address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "subnet-match" => {
+                                        "type" => LIST,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it the address fits in the given subnet definition. Value is a network IP address and the number of bits in the address' network prefix, written in \"slash notation\"; e.g. \"192.168.0.0/16\". An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 0L,
+                                        "max-length" => 2147483647L,
+                                        "value-type" => STRING
+                                    },
+                                    "up" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is currently up. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "virtual" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is a virtual interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    }
+                                }
+                            },
+                            "any-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that sockets using this interface should be bound to a wildcard address. The IPv6 wildcard address (::) will be used unless the java.net.preferIpV4Stack system property is set to true, in which case the IPv4 wildcard address (0.0.0.0) will be used. If a socket is bound to an IPv6 anylocal address on a dual-stack machine, it can accept both IPv6 and IPv4 traffic; if it is bound to an IPv4 (IPv4-mapped) anylocal address, it can only accept IPv4 traffic.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "inet-address",
+                                    "link-local-address",
+                                    "loopback",
+                                    "loopback-address",
+                                    "multicast",
+                                    "nic",
+                                    "nic-match",
+                                    "point-to-point",
+                                    "public-address",
+                                    "site-local-address",
+                                    "subnet-match",
+                                    "up",
+                                    "virtual",
+                                    "any",
+                                    "not"
+                                ]
+                            },
+                            "inet-address" => {
+                                "type" => STRING,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address matches the given value. Value is either an IP address in IPv6 or IPv4 dotted decimal notation, or a hostname that can be resolved to an IP address. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "link-local-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address is link-local. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"]
+                            },
+                            "loopback" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a loopback address.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"]
+                            },
+                            "loopback-address" => {
+                                "type" => STRING,
+                                "description" => "Attribute indicating that the IP address for this interface should be the given value, if a loopback interface exists on the machine. A 'loopback address' may not actually be configured on the machine's loopback interface. Differs from inet-address in that the given value will be used even if no NIC can be found that has the IP specified address associated with it. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "multicast" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface supports multicast.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"]
+                            },
+                            "nic" => {
+                                "type" => STRING,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has the given name. The name of a network interface (e.g. eth0, eth1, lo). An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "nic-match" => {
+                                "type" => STRING,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has a name that matches the given regular expression. Value is a regular expression against which the names of the network interfaces available on the machine can be matched to find an acceptable interface. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "not" => {
+                                "type" => OBJECT,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be that the IP address *does not* meet any of a nested set of criteria. The value of the attribute is a set of criteria (e.g. 'loopback') whose normal meaning is reversed. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"],
+                                "value-type" => {
+                                    "inet-address" => {
+                                        "type" => LIST,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address matches the given value. Value is either an IP address in IPv6 or IPv4 dotted decimal notation, or a hostname that can be resolved to an IP address. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 0L,
+                                        "max-length" => 2147483647L,
+                                        "value-type" => STRING
+                                    },
+                                    "link-local-address" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not the address is link-local. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "loopback" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a loopback address.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "loopback-address" => {
+                                        "type" => STRING,
+                                        "description" => "Attribute indicating that the IP address for this interface should be the given value, if a loopback interface exists on the machine. A 'loopback address' may not actually be configured on the machine's loopback interface. Differs from inet-address in that the given value will be used even if no NIC can be found that has the IP specified address associated with it. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => true,
+                                        "required" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "multicast" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface supports multicast.  An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "nic" => {
+                                        "type" => LIST,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has the given name. The name of a network interface (e.g. eth0, eth1, lo). An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 0L,
+                                        "max-length" => 2147483647L,
+                                        "value-type" => STRING
+                                    },
+                                    "nic-match" => {
+                                        "type" => LIST,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface has a name that matches the given regular expression. Value is a regular expression against which the names of the network interfaces available on the machine can be matched to find an acceptable interface. An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 0L,
+                                        "max-length" => 2147483647L,
+                                        "value-type" => STRING
+                                    },
+                                    "point-to-point" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface is a point-to-point interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "public-address" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a publicly routable address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "site-local-address" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it is a site-local address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "subnet-match" => {
+                                        "type" => LIST,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it the address fits in the given subnet definition. Value is a network IP address and the number of bits in the address' network prefix, written in \"slash notation\"; e.g. \"192.168.0.0/16\". An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 0L,
+                                        "max-length" => 2147483647L,
+                                        "value-type" => STRING
+                                    },
+                                    "up" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is currently up. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    },
+                                    "virtual" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is a virtual interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true
+                                    }
+                                }
+                            },
+                            "point-to-point" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not its network interface is a point-to-point interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"]
+                            },
+                            "public-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or not it is a publicly routable address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"]
+                            },
+                            "site-local-address" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it is a site-local address. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"]
+                            },
+                            "subnet-match" => {
+                                "type" => STRING,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether or it the address fits in the given subnet definition. Value is a network IP address and the number of bits in the address' network prefix, written in \"slash notation\"; e.g. \"192.168.0.0/16\". An 'undefined' value means this attribute is not relevant to the IP address selection.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "up" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is currently up. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"]
+                            },
+                            "virtual" => {
+                                "type" => BOOLEAN,
+                                "description" => "Attribute indicating that part of the selection criteria for choosing an IP address for this interface should be whether its network interface is a virtual interface. An 'undefined' or 'false' value means this attribute is not relevant to the IP address selection",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["any-address"]
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Remove an interface specification.",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "restart-required" => "all-services",
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => {}
+            }}
+        },
+        "deployment" => {
+            "description" => "A list of deployments available for use in the domain",
+            "model-description" => {"*" => {
+                "description" => "A deployment represents anything that can be deployed (e.g. an application such as Jakarta Enterprise Beans-JAR, WAR, EAR, any kind of standard archive such as RAR or JBoss-specific deployment) into a server.",
+                "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+                "attributes" => {
+                    "content" => {
+                        "type" => LIST,
+                        "description" => "List of pieces of content that comprise the deployment.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 1L,
+                        "value-type" => {
+                            "hash" => {
+                                "type" => BYTES,
+                                "description" => "The hash of managed deployment content that has been uploaded to the domain's or standalone server's deployment content repository.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "path",
+                                    "relative-to"
+                                ],
+                                "min-length" => 20L,
+                                "max-length" => 20L
+                            },
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "Path (relative or absolute) to unmanaged content that is part of the deployment.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => true,
+                                "alternatives" => ["hash"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "relative-to" => {
+                                "type" => STRING,
+                                "description" => "Name of a system path to which the value of the 'path' is relative. If not set, the 'path' is considered to be absolute.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "alternatives" => ["hash"],
+                                "requires" => ["path"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "archive" => {
+                                "type" => BOOLEAN,
+                                "description" => "Flag indicating whether unmanaged content is a zip archive (true) or exploded (false).",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "requires" => [
+                                    "path",
+                                    "hash"
+                                ]
+                            }
+                        },
+                        "access-type" => "read-only",
+                        "storage" => "configuration"
+                    },
+                    "managed" => {
+                        "type" => BOOLEAN,
+                        "description" => "Indicates if the deployment is managed (aka uses the ContentRepository).",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "access-type" => "read-only",
+                        "storage" => "runtime"
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "Unique identifier of the deployment. Must be unique across all deployments.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-only",
+                        "storage" => "configuration"
+                    },
+                    "runtime-name" => {
+                        "type" => STRING,
+                        "description" => "Name by which the deployment should be known within a server's runtime. This would be equivalent to the file name of a deployment file, and would form the basis for such things as default Java Enterprise Edition application and module names. This would typically be the same as 'name', but in some cases users may wish to have two deployments with the same 'runtime-name' (e.g. two versions of \"foo.war\") both available in the deployment content repository, in which case the deployments would need to have distinct 'name' values but would have the same 'runtime-name'.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-only",
+                        "storage" => "configuration"
+                    }
+                },
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Adds previously uploaded content to the list of content available for use. Does not actually deploy the content unless the 'enabled' parameter is 'true'.",
+                        "request-properties" => {
+                            "runtime-name" => {
+                                "type" => STRING,
+                                "description" => "Name by which the deployment should be known within a server's runtime. This would be equivalent to the file name of a deployment file, and would form the basis for such things as default Java Enterprise Edition application and module names. This would typically be the same as 'name', but in some cases users may wish to have two deployments with the same 'runtime-name' (e.g. two versions of \"foo.war\") both available in the deployment content repository, in which case the deployments would need to have distinct 'name' values but would have the same 'runtime-name'.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "content" => {
+                                "type" => LIST,
+                                "description" => "List of pieces of content that comprise the deployment.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 1L,
+                                "value-type" => {
+                                    "input-stream-index" => {
+                                        "type" => INT,
+                                        "description" => "The index into the operation's attached input streams of the input stream that contains deployment content that should be uploaded to the domain's or standalone server's deployment content repository.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "hash",
+                                            "bytes",
+                                            "url",
+                                            "path",
+                                            "relative-to",
+                                            "empty"
+                                        ],
+                                        "min" => 1L,
+                                        "max" => 2147483647L,
+                                        "filesystem-path" => true,
+                                        "attached-streams" => true
+                                    },
+                                    "hash" => {
+                                        "type" => BYTES,
+                                        "description" => "The hash of managed deployment content that has been uploaded to the domain's or standalone server's deployment content repository.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "input-stream-index",
+                                            "bytes",
+                                            "url",
+                                            "path",
+                                            "relative-to",
+                                            "empty"
+                                        ],
+                                        "min-length" => 20L,
+                                        "max-length" => 20L
+                                    },
+                                    "bytes" => {
+                                        "type" => BYTES,
+                                        "description" => "Byte array containing the deployment content that should uploaded to the domain's or standalone server's deployment content repository.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "input-stream-index",
+                                            "hash",
+                                            "url",
+                                            "path",
+                                            "relative-to",
+                                            "empty"
+                                        ]
+                                    },
+                                    "url" => {
+                                        "type" => STRING,
+                                        "description" => "The URL at which the deployment content is available for upload to the domain's or standalone server's deployment content repository.. Note that the URL must be accessible from the target of the operation (i.e. the Domain Controller or standalone server).",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "input-stream-index",
+                                            "hash",
+                                            "bytes",
+                                            "path",
+                                            "relative-to",
+                                            "empty"
+                                        ],
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "path" => {
+                                        "type" => STRING,
+                                        "description" => "Path (relative or absolute) to unmanaged content that is part of the deployment.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "input-stream-index",
+                                            "hash",
+                                            "bytes",
+                                            "url",
+                                            "empty"
+                                        ],
+                                        "requires" => ["archive"],
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "relative-to" => {
+                                        "type" => STRING,
+                                        "description" => "Name of a system path to which the value of the 'path' is relative. If not set, the 'path' is considered to be absolute.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "input-stream-index",
+                                            "hash",
+                                            "bytes",
+                                            "url",
+                                            "empty"
+                                        ],
+                                        "requires" => ["path"],
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "archive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Flag indicating whether unmanaged content is a zip archive (true) or exploded (false).",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "input-stream-index",
+                                            "bytes",
+                                            "url"
+                                        ],
+                                        "requires" => [
+                                            "path",
+                                            "hash",
+                                            "empty"
+                                        ]
+                                    },
+                                    "empty" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Indicates that the deployment to be added is empty - so without any content.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => true,
+                                        "default" => false,
+                                        "alternatives" => [
+                                            "hash",
+                                            "input-stream-index",
+                                            "bytes",
+                                            "url",
+                                            "path",
+                                            "relative-to"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "add-content" => {
+                        "operation-name" => "add-content",
+                        "description" => "Add contents to an existing deployment.",
+                        "request-properties" => {
+                            "content" => {
+                                "type" => LIST,
+                                "description" => "List of pieces of content to be added to the deployment.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "value-type" => {
+                                    "input-stream-index" => {
+                                        "type" => INT,
+                                        "description" => "The index into the operation's attached input streams of the input stream that contains deployment content that should be uploaded to the domain's or standalone server's deployment content repository.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "hash",
+                                            "bytes",
+                                            "url"
+                                        ],
+                                        "min" => 1L,
+                                        "max" => 2147483647L,
+                                        "filesystem-path" => true,
+                                        "attached-streams" => true
+                                    },
+                                    "hash" => {
+                                        "type" => BYTES,
+                                        "description" => "The hash of managed deployment content that has been uploaded to the domain's or standalone server's deployment content repository.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "input-stream-index",
+                                            "bytes",
+                                            "url"
+                                        ],
+                                        "min-length" => 20L,
+                                        "max-length" => 20L
+                                    },
+                                    "bytes" => {
+                                        "type" => BYTES,
+                                        "description" => "Byte array containing the deployment content that should uploaded to the domain's or standalone server's deployment content repository.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "input-stream-index",
+                                            "hash",
+                                            "url"
+                                        ]
+                                    },
+                                    "url" => {
+                                        "type" => STRING,
+                                        "description" => "The URL at which the deployment content is available for upload to the domain's or standalone server's deployment content repository.. Note that the URL must be accessible from the target of the operation (i.e. the Domain Controller or standalone server).",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true,
+                                        "alternatives" => [
+                                            "input-stream-index",
+                                            "hash",
+                                            "bytes"
+                                        ],
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "target-path" => {
+                                        "type" => STRING,
+                                        "description" => "The relative path of an exploded deployment of this content.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L,
+                                        "relative-to" => true
+                                    }
+                                }
+                            },
+                            "overwrite" => {
+                                "type" => BOOLEAN,
+                                "description" => "Indicates if added content should overwrite existing content.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => true
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "read-content" => {
+                        "operation-name" => "read-content",
+                        "description" => "Read the content of an existing deployment.",
+                        "request-properties" => {"path" => {
+                            "type" => STRING,
+                            "description" => "The relative path of the content to be read from an existing deployment.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L,
+                            "relative-to" => true
+                        }},
+                        "reply-properties" => {
+                            "type" => STRING,
+                            "description" => "The uuid of the attached stream.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => false,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "read-only" => true,
+                        "runtime-only" => false
+                    },
+                    "explode" => {
+                        "operation-name" => "explode",
+                        "description" => "Convert zip format managed deployment content to exploded format.",
+                        "request-properties" => {"path" => {
+                            "type" => STRING,
+                            "description" => "Relative path to an archive in a deployment to be exploded.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L,
+                            "relative-to" => true
+                        }},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "remove-content" => {
+                        "operation-name" => "remove-content",
+                        "description" => "Remove contents from an existing deployment.",
+                        "request-properties" => {"paths" => {
+                            "type" => LIST,
+                            "description" => "List of paths of content to be removed from the deployment.",
+                            "expressions-allowed" => true,
+                            "required" => true,
+                            "nillable" => false,
+                            "min-length" => 0L,
+                            "max-length" => 2147483647L,
+                            "relative-to" => true,
+                            "value-type" => STRING
+                        }},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "browse-content" => {
+                        "operation-name" => "browse-content",
+                        "description" => "List the pieces of content of a deployment.",
+                        "request-properties" => {
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "The relative path from a deployment to list the contents of.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "relative-to" => true
+                            },
+                            "archive" => {
+                                "type" => BOOLEAN,
+                                "description" => "If set to true, only the relative paths to archive files will be returned.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "depth" => {
+                                "type" => INT,
+                                "description" => "The depth to browse.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => -1
+                            }
+                        },
+                        "reply-properties" => {
+                            "type" => OBJECT,
+                            "description" => "The pieces of content of a deployment and some information about them.",
+                            "expressions-allowed" => false,
+                            "required" => true,
+                            "nillable" => false,
+                            "value-type" => {
+                                "directory" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "Indicates if the content is a folder or not.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false
+                                },
+                                "path" => {
+                                    "type" => STRING,
+                                    "description" => "Path (relative or absolute) to unmanaged content that is part of the deployment.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "file-size" => {
+                                    "type" => LONG,
+                                    "description" => "The size of the content if it is a file.",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "unit" => "BYTES"
+                                }
+                            }
+                        },
+                        "read-only" => true,
+                        "runtime-only" => false
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Remove a deployment from the list of content available for use. If the deployment is currently deployed in the runtime it will first be undeployed.",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "restart-required" => "all-services",
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => {}
+            }}
+        },
+        "management-client-content" => {
+            "description" => "Rollout plans defined for this domain.",
+            "model-description" => {"rollout-plans" => {
+                "description" => "Storage information about a set of named management update rollout plans useful to management clients that are stored in the domain content repository. The child resources under this resource provide access to these plans to management clients, allowing clients to use the plans by referencing them by name, avoiding the need to recreate them for each use.",
+                "attributes" => {"hash" => {
+                    "type" => BYTES,
+                    "description" => "The hash of all stored rollout plans. Used internally by host controllers to locate rollout plan content.",
+                    "expressions-allowed" => false,
+                    "required" => false,
+                    "nillable" => true,
+                    "min-length" => 20L,
+                    "max-length" => 20L,
+                    "access-type" => "read-only",
+                    "storage" => "configuration"
+                }},
+                "operations" => {"add" => {
+                    "operation-name" => "add",
+                    "description" => "Adds the capability to store named rollout plans.",
+                    "request-properties" => {"hash" => {
+                        "type" => BYTES,
+                        "description" => "The hash of all stored rollout plans. Used internally by host controllers to locate rollout plan content.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "min-length" => 20L,
+                        "max-length" => 20L
+                    }},
+                    "reply-properties" => {},
+                    "read-only" => false,
+                    "runtime-only" => false
+                }},
+                "notifications" => undefined,
+                "children" => {"rollout-plan" => {
+                    "description" => "A stored rollout plan.",
+                    "model-description" => {"*" => {
+                        "description" => "A stored rollout plan.",
+                        "attributes" => {
+                            "content" => {
+                                "type" => OBJECT,
+                                "description" => "The rollout plan content, in JBoss DMR form.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "access-type" => "read-write",
+                                "storage" => "runtime",
+                                "restart-required" => "no-services"
+                            },
+                            "hash" => {
+                                "type" => BYTES,
+                                "description" => "The hash of the rollout plan content.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 20L,
+                                "max-length" => 20L,
+                                "access-type" => "read-only",
+                                "storage" => "configuration"
+                            }
+                        },
+                        "operations" => {
+                            "add" => {
+                                "operation-name" => "add",
+                                "description" => "Adds a rollout plan to the persistent store.",
+                                "request-properties" => {"content" => {
+                                    "type" => OBJECT,
+                                    "description" => "The rollout plan content, in JBoss DMR form.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false
+                                }},
+                                "reply-properties" => {},
+                                "read-only" => false,
+                                "runtime-only" => false
+                            },
+                            "store" => {
+                                "operation-name" => "store",
+                                "description" => "Updates the content of an existing persisted rollout plan, after first checking that the provided 'hash' parameter matches the current rollout plan hash. Fails if the hashes do not match. Using this operation instead of the 'write-attribute' operation for the 'content' attribute provides a guarantee that the update will not conflict with a previous update unknown to the caller.",
+                                "request-properties" => {
+                                    "hash" => {
+                                        "type" => BYTES,
+                                        "description" => "The value the caller believes to be the hash of the rollout plan content that is being replaced.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 20L,
+                                        "max-length" => 20L
+                                    },
+                                    "content" => {
+                                        "type" => OBJECT,
+                                        "description" => "The updated rollout plan content, in JBoss DMR form.",
+                                        "expressions-allowed" => false,
+                                        "required" => true,
+                                        "nillable" => false
+                                    }
+                                },
+                                "reply-properties" => {},
+                                "read-only" => false,
+                                "runtime-only" => false
+                            },
+                            "remove" => {
+                                "operation-name" => "remove",
+                                "description" => "Removes a rollout plan from the persistent store.",
+                                "request-properties" => {},
+                                "reply-properties" => {},
+                                "read-only" => false,
+                                "runtime-only" => false
+                            }
+                        },
+                        "notifications" => undefined,
+                        "children" => {}
+                    }}
+                }}
+            }}
+        },
+        "system-property" => {
+            "description" => "A list of system properties to set on all servers in the domain.",
+            "model-description" => {"*" => {
+                "description" => "A system property to set on all servers in the domain.",
+                "access-constraints" => {"sensitive" => {"system-property" => {"type" => "core"}}},
+                "attributes" => {
+                    "boot-time" => {
+                        "type" => BOOLEAN,
+                        "description" => "If true the system property is passed on the command-line to the started server jvm. If false, it will be pushed to the server as part of the startup sequence.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "default" => true,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "value" => {
+                        "type" => STRING,
+                        "description" => "The value of the system property.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "min-length" => 0L,
+                        "max-length" => 2147483647L,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    }
+                },
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Adds a system property or updates an existing one.",
+                        "request-properties" => {
+                            "boot-time" => {
+                                "type" => BOOLEAN,
+                                "description" => "If true the system property is passed on the command-line to the started server jvm. If false, it will be pushed to the server as part of the startup sequence.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "value" => {
+                                "type" => STRING,
+                                "description" => "The value of the system property.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Removes a system property.",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "restart-required" => "all-services",
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => {}
+            }}
+        },
+        "extension" => {
+            "description" => "A list of extension modules.",
+            "model-description" => {"*" => {
+                "description" => "A module that extends the standard capabilities of a domain or a standalone server.",
+                "access-constraints" => {"sensitive" => {"extensions" => {"type" => "core"}}},
+                "attributes" => {"module" => {
+                    "type" => STRING,
+                    "description" => "The name of the module.",
+                    "expressions-allowed" => false,
+                    "required" => true,
+                    "nillable" => false,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L,
+                    "access-type" => "read-only",
+                    "storage" => "configuration"
+                }},
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Adds an extension.",
+                        "request-properties" => {"module" => {
+                            "type" => STRING,
+                            "description" => "The name of the module.",
+                            "expressions-allowed" => false,
+                            "required" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L,
+                            "deprecated" => {
+                                "since" => "6.0.0",
+                                "reason" => "The module parameter is deprecated as it isn't used."
+                            }
+                        }},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Removes an extension.",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => {"subsystem" => {
+                    "description" => "A subsystem provided by the extension. What is provided here is information about the xml schema and management interface provided by the subsystem, not the configuration of the subsystem itself.",
+                    "model-description" => {"*" => {
+                        "description" => "A subsystem provided by the extension. What is provided here is information about the xml schema and management interface provided by the subsystem, not the configuration of the subsystem itself.",
+                        "storage" => "runtime-only",
+                        "access-constraints" => {"sensitive" => {"extensions" => {"type" => "core"}}},
+                        "attributes" => {
+                            "management-major-version" => {
+                                "type" => INT,
+                                "description" => "Major version of the subsystem's management interface. May be undefined if the subsystem does not currently provide a versioned management interface.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "access-type" => "read-only",
+                                "storage" => "runtime"
+                            },
+                            "management-micro-version" => {
+                                "type" => INT,
+                                "description" => "Micro version of the subsystem's management interface. May be undefined if the subsystem does not currently provide a versioned management interface.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min" => 0L,
+                                "max" => 2147483647L,
+                                "access-type" => "read-only",
+                                "storage" => "runtime"
+                            },
+                            "management-minor-version" => {
+                                "type" => INT,
+                                "description" => "Minor version of the subsystem's management interface. May be undefined if the subsystem does not currently provide a versioned management interface.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min" => 0L,
+                                "max" => 2147483647L,
+                                "access-type" => "read-only",
+                                "storage" => "runtime"
+                            },
+                            "xml-namespaces" => {
+                                "type" => LIST,
+                                "description" => "A list of URIs for the XML namespaces supported by the subsystem's XML parser. May be empty if the extension did not clearly associate an XML namespace with a particular subsystem.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 0L,
+                                "max-length" => 2147483647L,
+                                "value-type" => STRING,
+                                "access-type" => "read-only",
+                                "storage" => "runtime"
+                            }
+                        },
+                        "operations" => undefined,
+                        "notifications" => undefined,
+                        "children" => {}
+                    }}
+                }}
+            }}
+        },
+        "server-group" => {
+            "description" => "A list of server groups available for use in the domain",
+            "model-description" => {"*" => {
+                "description" => "The server group configuration.",
+                "capabilities" => [{
+                    "name" => "org.wildfly.domain.server-group",
+                    "dynamic" => true,
+                    "dynamic-elements" => ["server-group"]
+                }],
+                "attributes" => {
+                    "graceful-startup" => {
+                        "type" => BOOLEAN,
+                        "description" => "Start the servers gracefully, queuing or cleanly rejecting incoming requests until the server is fully started.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "default" => true,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "management-subsystem-endpoint" => {
+                        "type" => BOOLEAN,
+                        "description" => "Set to true to have servers belonging to the server group connect back to the host controller using the endpoint from their remoting subsystem. The subsystem must be present for this to work.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "default" => false,
+                        "access-constraints" => {"sensitive" => {"management-interfaces" => {"type" => "core"}}},
+                        "access-type" => "read-only",
+                        "storage" => "configuration"
+                    },
+                    "profile" => {
+                        "type" => STRING,
+                        "description" => "The profile name.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "capability-reference" => "org.wildfly.domain.profile",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "feature-reference" => true,
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "socket-binding-default-interface" => {
+                        "type" => STRING,
+                        "description" => "The socket binding group default interface for this server.",
+                        "expressions-allowed" => false,
+                        "required" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "access-constraints" => {"sensitive" => {"socket-config" => {"type" => "core"}}},
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "socket-binding-group" => {
+                        "type" => STRING,
+                        "description" => "The default socket binding group used for servers associated with this group.",
+                        "expressions-allowed" => false,
+                        "required" => true,
+                        "nillable" => false,
+                        "capability-reference" => "org.wildfly.domain.socket-binding-group",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "feature-reference" => true,
+                        "access-constraints" => {"sensitive" => {"socket-binding-ref" => {"type" => "core"}}},
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    },
+                    "socket-binding-port-offset" => {
+                        "type" => INT,
+                        "description" => "The default offset to be added to the port values given by the socket binding group.",
+                        "expressions-allowed" => true,
+                        "required" => false,
+                        "nillable" => true,
+                        "default" => 0,
+                        "min" => -65535L,
+                        "max" => 65535L,
+                        "access-constraints" => {"sensitive" => {"socket-config" => {"type" => "core"}}},
+                        "access-type" => "read-write",
+                        "storage" => "configuration",
+                        "restart-required" => "no-services"
+                    }
+                },
+                "operations" => {
+                    "add" => {
+                        "operation-name" => "add",
+                        "description" => "Add a new server group.",
+                        "request-properties" => {
+                            "graceful-startup" => {
+                                "type" => BOOLEAN,
+                                "description" => "Start the servers gracefully, queuing or cleanly rejecting incoming requests until the server is fully started.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "management-subsystem-endpoint" => {
+                                "type" => BOOLEAN,
+                                "description" => "Set to true to have servers belonging to the server group connect back to the host controller using the endpoint from their remoting subsystem. The subsystem must be present for this to work.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "profile" => {
+                                "type" => STRING,
+                                "description" => "The profile name.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "capability-reference" => "org.wildfly.domain.profile",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "feature-reference" => true
+                            },
+                            "socket-binding-default-interface" => {
+                                "type" => STRING,
+                                "description" => "The socket binding group default interface for this server.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "socket-binding-group" => {
+                                "type" => STRING,
+                                "description" => "The default socket binding group used for servers associated with this group.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "capability-reference" => "org.wildfly.domain.socket-binding-group",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "feature-reference" => true
+                            },
+                            "socket-binding-port-offset" => {
+                                "type" => INT,
+                                "description" => "The default offset to be added to the port values given by the socket binding group.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => 0,
+                                "min" => -65535L,
+                                "max" => 65535L
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "suspend-servers" => {
+                        "operation-name" => "suspend-servers",
+                        "description" => "Suspends operations on all servers in the server group. All current operations will be allowed to finish, and new operations will be rejected.",
+                        "request-properties" => {
+                            "timeout" => {
+                                "type" => INT,
+                                "description" => "Timeout in seconds. If this is zero the operation will return immediately, -1 means that it will wait indefinitely. Note that the operation will not roll back if the timeout is exceeded, it just means that not all current requests completed in the specified timeout.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => 0,
+                                "unit" => "SECONDS",
+                                "alternatives" => ["suspend-timeout"],
+                                "deprecated" => {
+                                    "since" => "9.0.0",
+                                    "reason" => "Use suspend-timeout instead."
+                                }
+                            },
+                            "suspend-timeout" => {
+                                "type" => INT,
+                                "description" => "The suspend operation timeout in seconds. If this is zero (the default) the operation will return immediately. A value larger than zero means the operation will wait up to this many seconds to complete before returning. A value smaller than zero means that the operation will wait indefinitely for all active requests to finish. Note that the operation will not roll back if the timeout is exceeded, it just means that not all current requests completed in the specified timeout.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => 0,
+                                "unit" => "SECONDS",
+                                "alternatives" => ["timeout"]
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => true
+                    },
+                    "kill-servers" => {
+                        "operation-name" => "kill-servers",
+                        "description" => "Kill all server processes in the server group. In case the server is not in the stopping state, it will attempt to stop the server first. This operation may not work on all platforms and will try to destroy the process if not available.",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => true
+                    },
+                    "reload-servers" => {
+                        "operation-name" => "reload-servers",
+                        "description" => "Reloads all servers belonging to the server group currently running in the domain.",
+                        "request-properties" => {
+                            "blocking" => {
+                                "type" => BOOLEAN,
+                                "description" => "Wait until the servers are fully started before returning from the operation.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "start-mode" => {
+                                "type" => STRING,
+                                "description" => "The mode the servers should start reload in, can be either suspend or normal.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => "normal",
+                                "allowed" => [
+                                    "normal",
+                                    "suspend"
+                                ]
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => true
+                    },
+                    "start-servers" => {
+                        "operation-name" => "start-servers",
+                        "description" => "Starts all configured servers belonging to the server group in the domain that are not currently running.",
+                        "request-properties" => {
+                            "blocking" => {
+                                "type" => BOOLEAN,
+                                "description" => "Wait until the servers are fully started before returning from the operation.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "start-mode" => {
+                                "type" => STRING,
+                                "description" => "The mode the servers should start running in, can be either suspend or normal.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => "normal",
+                                "allowed" => [
+                                    "normal",
+                                    "suspend"
+                                ]
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => true
+                    },
+                    "restart-servers" => {
+                        "operation-name" => "restart-servers",
+                        "description" => "Restarts all servers belonging to the server group currently running in the domain.",
+                        "request-properties" => {
+                            "blocking" => {
+                                "type" => BOOLEAN,
+                                "description" => "Wait until the servers are fully started before returning from the operation.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "start-mode" => {
+                                "type" => STRING,
+                                "description" => "The mode the servers should restart in, can be either suspend or normal.",
+                                "expressions-allowed" => true,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => "normal",
+                                "allowed" => [
+                                    "normal",
+                                    "suspend"
+                                ]
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => true
+                    },
+                    "resume-servers" => {
+                        "operation-name" => "resume-servers",
+                        "description" => "Resumes operations on all servers in the server group",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => true
+                    },
+                    "replace-deployment" => {
+                        "operation-name" => "replace-deployment",
+                        "description" => "Replace existing content in the runtime with new content. The new content must have been previously uploaded to the deployment content repository.",
+                        "request-properties" => {
+                            "to-replace" => {
+                                "type" => STRING,
+                                "description" => "The name of the content that is to be replaced.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "name" => {
+                                "type" => STRING,
+                                "description" => "The name of the new content.",
+                                "expressions-allowed" => false,
+                                "required" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "runtime-name" => {
+                                "type" => STRING,
+                                "description" => "Name by which the deployment should be known within a server's runtime. This would be equivalent to the file name of a deployment file, and would form the basis for such things as default Java Enterprise Edition application and module names. This would typically be the same as 'name', but in some cases users may wish to have two deployments with the same 'runtime-name' (e.g. two versions of \"foo.war\") both available in the deployment content repository, in which case the deployments would need to have distinct 'name' values but would have the same 'runtime-name'.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => false
+                    },
+                    "stop-servers" => {
+                        "operation-name" => "stop-servers",
+                        "description" => "Stops all servers belonging to the server group currently running in the domain.",
+                        "request-properties" => {
+                            "blocking" => {
+                                "type" => BOOLEAN,
+                                "description" => "Wait until the servers are fully stopped before returning from the operation.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "timeout" => {
+                                "type" => INT,
+                                "description" => "The graceful shutdown timeout. If this is zero then a graceful shutdown will not be attempted, if this is -1 then the server will wait for a graceful shutdown indefinitely.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => 0,
+                                "unit" => "SECONDS",
+                                "alternatives" => ["suspend-timeout"],
+                                "deprecated" => {
+                                    "since" => "9.0.0",
+                                    "reason" => "Use suspend-timeout instead."
+                                }
+                            },
+                            "suspend-timeout" => {
+                                "type" => INT,
+                                "description" => "The graceful stop timeout in seconds. If this is zero (the default) then the server will stop immediately. A value larger than zero means the server will wait up to this many seconds for all active requests to finish. A value smaller than zero means that the server will wait indefinitely for all active requests to finish.",
+                                "expressions-allowed" => false,
+                                "required" => false,
+                                "nillable" => true,
+                                "default" => 0,
+                                "unit" => "SECONDS",
+                                "alternatives" => ["timeout"]
+                            }
+                        },
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => true
+                    },
+                    "destroy-servers" => {
+                        "operation-name" => "destroy-servers",
+                        "description" => "Destroy the server processes in the server group. In case the server is not in the stopping state, it will attempt to stop the server first.",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "runtime-only" => true
+                    },
+                    "remove" => {
+                        "operation-name" => "remove",
+                        "description" => "Remove an existing new server group.",
+                        "request-properties" => {},
+                        "reply-properties" => {},
+                        "read-only" => false,
+                        "restart-required" => "all-services",
+                        "runtime-only" => false
+                    }
+                },
+                "notifications" => undefined,
+                "children" => {
+                    "deployment" => {
+                        "description" => "A list of deployments available for use in the server group.",
+                        "model-description" => {"*" => {
+                            "description" => "A deployment represents anything that can be deployed (e.g. an application such as Jakarta Enterprise Beans-JAR, WAR, EAR, any kind of standard archive such as RAR or JBoss-specific deployment) into a server.",
+                            "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+                            "attributes" => {
+                                "enabled" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "Boolean indicating whether the deployment content is currently deployed in the runtime (or should be deployed in the runtime the next time the server starts.)",
+                                    "expressions-allowed" => false,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => false,
+                                    "access-type" => "read-only",
+                                    "storage" => "configuration"
+                                },
+                                "managed" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "Indicates if the deployment is managed (aka uses the ContentRepository).",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "access-type" => "read-only",
+                                    "storage" => "runtime"
+                                },
+                                "name" => {
+                                    "type" => STRING,
+                                    "description" => "Unique identifier of the deployment. Must be unique across all deployments.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-only",
+                                    "storage" => "configuration"
+                                },
+                                "runtime-name" => {
+                                    "type" => STRING,
+                                    "description" => "Name by which the deployment should be known within a server's runtime. This would be equivalent to the file name of a deployment file, and would form the basis for such things as default Java Enterprise Edition application and module names. This would typically be the same as 'name', but in some cases users may wish to have two deployments with the same 'runtime-name' (e.g. two versions of \"foo.war\") both available in the deployment content repository, in which case the deployments would need to have distinct 'name' values but would have the same 'runtime-name'.",
+                                    "expressions-allowed" => false,
+                                    "required" => true,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-only",
+                                    "storage" => "configuration"
+                                }
+                            },
+                            "operations" => {
+                                "add" => {
+                                    "operation-name" => "add",
+                                    "description" => "Adds previously uploaded content to the list of content available for use. Does not actually deploy the content unless the 'enabled' parameter is 'true'.",
+                                    "request-properties" => {
+                                        "runtime-name" => {
+                                            "type" => STRING,
+                                            "description" => "Name by which the deployment should be known within a server's runtime. This would be equivalent to the file name of a deployment file, and would form the basis for such things as default Java Enterprise Edition application and module names. This would typically be the same as 'name', but in some cases users may wish to have two deployments with the same 'runtime-name' (e.g. two versions of \"foo.war\") both available in the deployment content repository, in which case the deployments would need to have distinct 'name' values but would have the same 'runtime-name'.",
+                                            "expressions-allowed" => false,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "enabled" => {
+                                            "type" => BOOLEAN,
+                                            "description" => "Boolean indicating whether the deployment content is currently deployed in the runtime (or should be deployed in the runtime the next time the server starts.)",
+                                            "expressions-allowed" => false,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "default" => false
+                                        }
+                                    },
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "redeploy" => {
+                                    "operation-name" => "redeploy",
+                                    "description" => "Undeploy existing content from the runtime and deploy it again.",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "remove" => {
+                                    "operation-name" => "remove",
+                                    "description" => "Remove a deployment from the list of content available for use. If the deployment is currently deployed in the runtime it will first be undeployed.",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "restart-required" => "all-services",
+                                    "runtime-only" => false
+                                },
+                                "deploy" => {
+                                    "operation-name" => "deploy",
+                                    "description" => "Deploy the specified deployment content into the runtime, optionally replacing existing content.",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "undeploy" => {
+                                    "operation-name" => "undeploy",
+                                    "description" => "Undeploy content from the runtime. The content remains in the list of content available for use.",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                }
+                            },
+                            "notifications" => undefined,
+                            "children" => {}
+                        }}
+                    },
+                    "jvm" => {
+                        "description" => "The named jvm.",
+                        "model-description" => {"*" => {
+                            "description" => "The JVM configuration for managed processes / servers.",
+                            "attributes" => {
+                                "agent-lib" => {
+                                    "type" => STRING,
+                                    "description" => "The JVM agent lib.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "agent-path" => {
+                                    "type" => STRING,
+                                    "description" => "The JVM agent path.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "env-classpath-ignored" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "Ignore the environment classpath.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "environment-variables" => {
+                                    "type" => OBJECT,
+                                    "description" => "The JVM environment variables.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "value-type" => STRING,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "heap-size" => {
+                                    "type" => STRING,
+                                    "description" => "The initial heap size allocated by the JVM.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "java-agent" => {
+                                    "type" => STRING,
+                                    "description" => "The java agent.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "java-home" => {
+                                    "type" => STRING,
+                                    "description" => "The java home",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "jvm-options" => {
+                                    "type" => LIST,
+                                    "description" => "The JVM options.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 0L,
+                                    "max-length" => 2147483647L,
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "value-type" => STRING,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "launch-command" => {
+                                    "type" => STRING,
+                                    "description" => "Command prefixed to JVM at launch.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "max-heap-size" => {
+                                    "type" => STRING,
+                                    "description" => "The maximum heap size that can be allocated by the JVM.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "max-permgen-size" => {
+                                    "type" => STRING,
+                                    "description" => "The maximum size of the permanent generation.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "deprecated" => {
+                                        "since" => "4.0.0",
+                                        "reason" => "The JVM no longer provides a separate Permanent Generation space."
+                                    },
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "module-options" => {
+                                    "type" => LIST,
+                                    "description" => "The options passed to JBoss Modules during the boot of the server. Note that if a -javaent: is defined in the module options the jboss-modules.jar will be automatically added as a Java agent.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 0L,
+                                    "max-length" => 2147483647L,
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "value-type" => STRING,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "permgen-size" => {
+                                    "type" => STRING,
+                                    "description" => "The initial permanent generation size.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "deprecated" => {
+                                        "since" => "4.0.0",
+                                        "reason" => "The JVM no longer provides a separate Permanent Generation space."
+                                    },
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "stack-size" => {
+                                    "type" => STRING,
+                                    "description" => "The JVM stack size settings.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "type" => {
+                                    "type" => STRING,
+                                    "description" => "The JVM type can be either SUN or IBM",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "allowed" => [
+                                        "ORACLE",
+                                        "IBM",
+                                        "OTHER",
+                                        "SUN"
+                                    ],
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                }
+                            },
+                            "operations" => {
+                                "add" => {
+                                    "operation-name" => "add",
+                                    "description" => "Add a new JVM configuration.",
+                                    "request-properties" => {
+                                        "agent-lib" => {
+                                            "type" => STRING,
+                                            "description" => "The JVM agent lib.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "agent-path" => {
+                                            "type" => STRING,
+                                            "description" => "The JVM agent path.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "env-classpath-ignored" => {
+                                            "type" => BOOLEAN,
+                                            "description" => "Ignore the environment classpath.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true
+                                        },
+                                        "environment-variables" => {
+                                            "type" => OBJECT,
+                                            "description" => "The JVM environment variables.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "value-type" => STRING
+                                        },
+                                        "heap-size" => {
+                                            "type" => STRING,
+                                            "description" => "The initial heap size allocated by the JVM.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "java-agent" => {
+                                            "type" => STRING,
+                                            "description" => "The java agent.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "java-home" => {
+                                            "type" => STRING,
+                                            "description" => "The java home",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "jvm-options" => {
+                                            "type" => LIST,
+                                            "description" => "The JVM options.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 0L,
+                                            "max-length" => 2147483647L,
+                                            "value-type" => STRING
+                                        },
+                                        "launch-command" => {
+                                            "type" => STRING,
+                                            "description" => "Command prefixed to JVM at launch.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "max-heap-size" => {
+                                            "type" => STRING,
+                                            "description" => "The maximum heap size that can be allocated by the JVM.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "max-permgen-size" => {
+                                            "type" => STRING,
+                                            "description" => "The maximum size of the permanent generation.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L,
+                                            "deprecated" => {
+                                                "since" => "4.0.0",
+                                                "reason" => "The JVM no longer provides a separate Permanent Generation space."
+                                            }
+                                        },
+                                        "module-options" => {
+                                            "type" => LIST,
+                                            "description" => "The options passed to JBoss Modules during the boot of the server. Note that if a -javaent: is defined in the module options the jboss-modules.jar will be automatically added as a Java agent.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 0L,
+                                            "max-length" => 2147483647L,
+                                            "value-type" => STRING
+                                        },
+                                        "permgen-size" => {
+                                            "type" => STRING,
+                                            "description" => "The initial permanent generation size.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L,
+                                            "deprecated" => {
+                                                "since" => "4.0.0",
+                                                "reason" => "The JVM no longer provides a separate Permanent Generation space."
+                                            }
+                                        },
+                                        "stack-size" => {
+                                            "type" => STRING,
+                                            "description" => "The JVM stack size settings.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "type" => {
+                                            "type" => STRING,
+                                            "description" => "The JVM type can be either SUN or IBM",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "allowed" => [
+                                                "ORACLE",
+                                                "IBM",
+                                                "OTHER",
+                                                "SUN"
+                                            ]
+                                        }
+                                    },
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "remove-jvm-option" => {
+                                    "operation-name" => "remove-jvm-option",
+                                    "description" => "Remove a jvm option.",
+                                    "request-properties" => {"jvm-option" => {
+                                        "type" => STRING,
+                                        "description" => "A JVM option.",
+                                        "expressions-allowed" => true,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }},
+                                    "reply-properties" => {},
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "add-jvm-option" => {
+                                    "operation-name" => "add-jvm-option",
+                                    "description" => "Add a jvm option.",
+                                    "request-properties" => {"jvm-option" => {
+                                        "type" => STRING,
+                                        "description" => "A JVM option.",
+                                        "expressions-allowed" => true,
+                                        "required" => true,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }},
+                                    "reply-properties" => {},
+                                    "access-constraints" => {"sensitive" => {"jvm" => {"type" => "core"}}},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "remove" => {
+                                    "operation-name" => "remove",
+                                    "description" => "Remove an existing JVM configuration.",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "restart-required" => "all-services",
+                                    "runtime-only" => false
+                                }
+                            },
+                            "notifications" => undefined,
+                            "children" => {}
+                        }}
+                    },
+                    "deployment-overlay" => {
+                        "description" => "Links between a defined deployment overlay and deployments in this server group",
+                        "model-description" => {"*" => {
+                            "description" => "A deployment overlay",
+                            "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+                            "attributes" => {},
+                            "operations" => {
+                                "add" => {
+                                    "operation-name" => "add",
+                                    "description" => "Adds a deployment overlay",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "redeploy-links" => {
+                                    "operation-name" => "redeploy-links",
+                                    "description" => "Redeploys the deployments affected by this overlay.",
+                                    "request-properties" => {"deployments" => {
+                                        "type" => LIST,
+                                        "description" => "List of deployment runtime names to be redeployed. If this list is empty or 'undefined' then all affected deployments will be redeployed.",
+                                        "expressions-allowed" => false,
+                                        "required" => false,
+                                        "nillable" => true,
+                                        "min-length" => 0L,
+                                        "max-length" => 2147483647L,
+                                        "value-type" => STRING
+                                    }},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "remove" => {
+                                    "operation-name" => "remove",
+                                    "description" => "Removes a deployment overlay",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "restart-required" => "all-services",
+                                    "runtime-only" => false
+                                }
+                            },
+                            "notifications" => undefined,
+                            "children" => {"deployment" => {
+                                "description" => "The deployment that this deployment overlay is linked to",
+                                "model-description" => {"*" => {
+                                    "description" => "The deployment that this deployment overlay is linked to",
+                                    "access-constraints" => {"application" => {"deployment" => {"type" => "core"}}},
+                                    "attributes" => {},
+                                    "operations" => {
+                                        "add" => {
+                                            "operation-name" => "add",
+                                            "description" => "Adds a deployment overlay link",
+                                            "request-properties" => {},
+                                            "reply-properties" => {},
+                                            "read-only" => false,
+                                            "runtime-only" => false
+                                        },
+                                        "remove" => {
+                                            "operation-name" => "remove",
+                                            "description" => "Removes a deployment overlay link",
+                                            "request-properties" => {"redeploy-affected" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "If set to 'true', redeploy the deployments affected by this overlay after removal.",
+                                                "expressions-allowed" => false,
+                                                "required" => false,
+                                                "nillable" => true,
+                                                "default" => false
+                                            }},
+                                            "reply-properties" => {},
+                                            "read-only" => false,
+                                            "runtime-only" => false
+                                        }
+                                    },
+                                    "notifications" => undefined,
+                                    "children" => {}
+                                }}
+                            }}
+                        }}
+                    },
+                    "system-property" => {
+                        "description" => "A list of system properties to set on all servers in this server-group.",
+                        "model-description" => {"*" => {
+                            "description" => "A system property to set on all servers in this server-group.",
+                            "access-constraints" => {"sensitive" => {"system-property" => {"type" => "core"}}},
+                            "attributes" => {
+                                "boot-time" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "If true the system property is passed on the command-line to the started server jvm. If false, it will be pushed to the server as part of the startup sequence.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "default" => true,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                },
+                                "value" => {
+                                    "type" => STRING,
+                                    "description" => "The value of the system property.",
+                                    "expressions-allowed" => true,
+                                    "required" => false,
+                                    "nillable" => true,
+                                    "min-length" => 0L,
+                                    "max-length" => 2147483647L,
+                                    "access-type" => "read-write",
+                                    "storage" => "configuration",
+                                    "restart-required" => "no-services"
+                                }
+                            },
+                            "operations" => {
+                                "add" => {
+                                    "operation-name" => "add",
+                                    "description" => "Adds a system property or updates an existing one.",
+                                    "request-properties" => {
+                                        "boot-time" => {
+                                            "type" => BOOLEAN,
+                                            "description" => "If true the system property is passed on the command-line to the started server jvm. If false, it will be pushed to the server as part of the startup sequence.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "default" => true
+                                        },
+                                        "value" => {
+                                            "type" => STRING,
+                                            "description" => "The value of the system property.",
+                                            "expressions-allowed" => true,
+                                            "required" => false,
+                                            "nillable" => true,
+                                            "min-length" => 0L,
+                                            "max-length" => 2147483647L
+                                        }
+                                    },
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "runtime-only" => false
+                                },
+                                "remove" => {
+                                    "operation-name" => "remove",
+                                    "description" => "Removes a system property.",
+                                    "request-properties" => {},
+                                    "reply-properties" => {},
+                                    "read-only" => false,
+                                    "restart-required" => "all-services",
+                                    "runtime-only" => false
+                                }
+                            },
+                            "notifications" => undefined,
+                            "children" => {}
+                        }}
+                    }
+                }
+            }}
+        }
+    }
+}

--- a/tools/src/main/resources/legacy-models/host-resource-definition-wf29.dmr
+++ b/tools/src/main/resources/legacy-models/host-resource-definition-wf29.dmr
@@ -1,0 +1,35 @@
+{
+    "description" => "The root node of the host-level management model.",
+    "attributes" => {},
+    "operations" => {"add" => {
+        "operation-name" => "add",
+        "description" => "Add a host controller using an empty host configuration.",
+        "request-properties" => {
+            "persist-name" => {
+                "type" => BOOLEAN,
+                "description" => "If set to true, the host controller name will be written to the host configuration file. The default value is false, and the name is not persisted.",
+                "expressions-allowed" => false,
+                "required" => false,
+                "nillable" => true,
+                "default" => false
+            },
+            "is-domain-controller" => {
+                "type" => BOOLEAN,
+                "description" => "Indicates whether this host is a domain controller or expects a remote domain controller to be configured.",
+                "expressions-allowed" => false,
+                "required" => false,
+                "nillable" => true,
+                "default" => true,
+                "deprecated" => {
+                    "since" => "6.0.0",
+                    "reason" => "Use write-attribute to configure the host controller domain-controller attribute."
+                }
+            }
+        },
+        "reply-properties" => {},
+        "read-only" => false,
+        "runtime-only" => false
+    }},
+    "notifications" => undefined,
+    "children" => {}
+}

--- a/tools/src/main/resources/legacy-models/standalone-model-versions-wf29.dmr
+++ b/tools/src/main/resources/legacy-models/standalone-model-versions-wf29.dmr
@@ -1,0 +1,442 @@
+{
+    "core" => {
+        "standalone" => {
+            "management-major-version" => 22,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0
+        },
+        "product" => {
+            "product-name" => "WildFly Full",
+            "product-version" => "29.0.0.Final"
+        }
+    },
+    "subsystem" => {
+        "batch-jberet" => {
+            "management-major-version" => 3,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:batch-jberet:1.0",
+                "urn:jboss:domain:batch-jberet:2.0",
+                "urn:jboss:domain:batch-jberet:3.0"
+            ]
+        },
+        "bean-validation" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:bean-validation:1.0"]
+        },
+        "core-management" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:core-management:1.0"]
+        },
+        "datasources" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:datasources:1.1",
+                "urn:jboss:domain:datasources:1.2",
+                "urn:jboss:domain:datasources:2.0",
+                "urn:jboss:domain:datasources:3.0",
+                "urn:jboss:domain:datasources:4.0",
+                "urn:jboss:domain:datasources:5.0",
+                "urn:jboss:domain:datasources:6.0",
+                "urn:jboss:domain:datasources:7.0"
+            ]
+        },
+        "deployment-scanner" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:deployment-scanner:1.0",
+                "urn:jboss:domain:deployment-scanner:1.1",
+                "urn:jboss:domain:deployment-scanner:2.0"
+            ]
+        },
+        "discovery" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:discovery:1.0"]
+        },
+        "distributable-ejb" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:distributable-ejb:1.0"]
+        },
+        "distributable-web" => {
+            "management-major-version" => 3,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:distributable-web:1.0",
+                "urn:jboss:domain:distributable-web:2.0",
+                "urn:jboss:domain:distributable-web:3.0"
+            ]
+        },
+        "ee" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:ee:1.0",
+                "urn:jboss:domain:ee:1.1",
+                "urn:jboss:domain:ee:1.2",
+                "urn:jboss:domain:ee:2.0",
+                "urn:jboss:domain:ee:3.0",
+                "urn:jboss:domain:ee:4.0",
+                "urn:jboss:domain:ee:5.0",
+                "urn:jboss:domain:ee:6.0"
+            ]
+        },
+        "ee-security" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:ee-security:1.0"]
+        },
+        "ejb3" => {
+            "management-major-version" => 10,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:ejb3:1.0",
+                "urn:jboss:domain:ejb3:1.1",
+                "urn:jboss:domain:ejb3:1.2",
+                "urn:jboss:domain:ejb3:1.3",
+                "urn:jboss:domain:ejb3:1.4",
+                "urn:jboss:domain:ejb3:1.5",
+                "urn:jboss:domain:ejb3:2.0",
+                "urn:jboss:domain:ejb3:3.0",
+                "urn:jboss:domain:ejb3:4.0",
+                "urn:jboss:domain:ejb3:5.0",
+                "urn:jboss:domain:ejb3:6.0",
+                "urn:jboss:domain:ejb3:7.0",
+                "urn:jboss:domain:ejb3:8.0",
+                "urn:jboss:domain:ejb3:9.0",
+                "urn:jboss:domain:ejb3:10.0"
+            ]
+        },
+        "elytron" => {
+            "management-major-version" => 18,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:wildfly:elytron:1.0",
+                "urn:wildfly:elytron:1.1",
+                "urn:wildfly:elytron:1.2",
+                "urn:wildfly:elytron:2.0",
+                "urn:wildfly:elytron:3.0",
+                "urn:wildfly:elytron:4.0",
+                "urn:wildfly:elytron:5.0",
+                "urn:wildfly:elytron:6.0",
+                "urn:wildfly:elytron:7.0",
+                "urn:wildfly:elytron:8.0",
+                "urn:wildfly:elytron:9.0",
+                "urn:wildfly:elytron:10.0",
+                "urn:wildfly:elytron:11.0",
+                "urn:wildfly:elytron:12.0",
+                "urn:wildfly:elytron:13.0",
+                "urn:wildfly:elytron:14.0",
+                "urn:wildfly:elytron:15.0",
+                "urn:wildfly:elytron:15.1",
+                "urn:wildfly:elytron:16.0",
+                "urn:wildfly:elytron:17.0",
+                "urn:wildfly:elytron:18.0"
+            ]
+        },
+        "elytron-oidc-client" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:wildfly:elytron-oidc-client:1.0",
+                "urn:wildfly:elytron-oidc-client:2.0"
+            ]
+        },
+        "health" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:wildfly:health:1.0"]
+        },
+        "infinispan" => {
+            "management-major-version" => 17,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:infinispan:1.5",
+                "urn:jboss:domain:infinispan:2.0",
+                "urn:jboss:domain:infinispan:3.0",
+                "urn:jboss:domain:infinispan:4.0",
+                "urn:jboss:domain:infinispan:5.0",
+                "urn:jboss:domain:infinispan:6.0",
+                "urn:jboss:domain:infinispan:7.0",
+                "urn:jboss:domain:infinispan:8.0",
+                "urn:jboss:domain:infinispan:9.0",
+                "urn:jboss:domain:infinispan:9.1",
+                "urn:jboss:domain:infinispan:10.0",
+                "urn:jboss:domain:infinispan:11.0",
+                "urn:jboss:domain:infinispan:12.0",
+                "urn:jboss:domain:infinispan:13.0",
+                "urn:jboss:domain:infinispan:14.0"
+            ]
+        },
+        "io" => {
+            "management-major-version" => 5,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:io:1.0",
+                "urn:jboss:domain:io:1.1",
+                "urn:jboss:domain:io:2.0",
+                "urn:jboss:domain:io:3.0"
+            ]
+        },
+        "jaxrs" => {
+            "management-major-version" => 4,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jaxrs:1.0",
+                "urn:jboss:domain:jaxrs:2.0",
+                "urn:jboss:domain:jaxrs:3.0"
+            ]
+        },
+        "jca" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jca:1.1",
+                "urn:jboss:domain:jca:2.0",
+                "urn:jboss:domain:jca:3.0",
+                "urn:jboss:domain:jca:4.0",
+                "urn:jboss:domain:jca:5.0",
+                "urn:jboss:domain:jca:6.0"
+            ]
+        },
+        "jdr" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:jdr:1.0"]
+        },
+        "jmx" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 2,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jmx:1.0",
+                "urn:jboss:domain:jmx:1.1",
+                "urn:jboss:domain:jmx:1.2",
+                "urn:jboss:domain:jmx:1.3"
+            ]
+        },
+        "jpa" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 2,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jpa:1.1",
+                "urn:jboss:domain:jpa:1.0"
+            ]
+        },
+        "jsf" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 1,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jsf:1.0",
+                "urn:jboss:domain:jsf:1.1"
+            ]
+        },
+        "logging" => {
+            "management-major-version" => 9,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:logging:1.0",
+                "urn:jboss:domain:logging:1.1",
+                "urn:jboss:domain:logging:1.2",
+                "urn:jboss:domain:logging:1.3",
+                "urn:jboss:domain:logging:1.4",
+                "urn:jboss:domain:logging:1.5",
+                "urn:jboss:domain:logging:2.0",
+                "urn:jboss:domain:logging:3.0",
+                "urn:jboss:domain:logging:4.0",
+                "urn:jboss:domain:logging:5.0",
+                "urn:jboss:domain:logging:6.0",
+                "urn:jboss:domain:logging:7.0",
+                "urn:jboss:domain:logging:8.0"
+            ]
+        },
+        "mail" => {
+            "management-major-version" => 4,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:mail:1.0",
+                "urn:jboss:domain:mail:1.1",
+                "urn:jboss:domain:mail:1.2",
+                "urn:jboss:domain:mail:2.0",
+                "urn:jboss:domain:mail:3.0",
+                "urn:jboss:domain:mail:4.0"
+            ]
+        },
+        "metrics" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:wildfly:metrics:1.0"]
+        },
+        "microprofile-config-smallrye" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:wildfly:microprofile-config-smallrye:1.0",
+                "urn:wildfly:microprofile-config-smallrye:2.0"
+            ]
+        },
+        "microprofile-jwt-smallrye" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:wildfly:microprofile-jwt-smallrye:1.0"]
+        },
+        "naming" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 1,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:naming:1.0",
+                "urn:jboss:domain:naming:1.1",
+                "urn:jboss:domain:naming:1.2",
+                "urn:jboss:domain:naming:1.3",
+                "urn:jboss:domain:naming:1.4",
+                "urn:jboss:domain:naming:2.0"
+            ]
+        },
+        "pojo" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:pojo:1.0"]
+        },
+        "remoting" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:remoting:1.0",
+                "urn:jboss:domain:remoting:1.1",
+                "urn:jboss:domain:remoting:1.2",
+                "urn:jboss:domain:remoting:2.0",
+                "urn:jboss:domain:remoting:3.0",
+                "urn:jboss:domain:remoting:4.0",
+                "urn:jboss:domain:remoting:5.0"
+            ]
+        },
+        "request-controller" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 1,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:request-controller:1.0"]
+        },
+        "resource-adapters" => {
+            "management-major-version" => 7,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:resource-adapters:1.0",
+                "urn:jboss:domain:resource-adapters:1.1",
+                "urn:jboss:domain:resource-adapters:2.0",
+                "urn:jboss:domain:resource-adapters:3.0",
+                "urn:jboss:domain:resource-adapters:4.0",
+                "urn:jboss:domain:resource-adapters:5.0",
+                "urn:jboss:domain:resource-adapters:6.0",
+                "urn:jboss:domain:resource-adapters:6.1",
+                "urn:jboss:domain:resource-adapters:7.0"
+            ]
+        },
+        "sar" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:sar:1.0"]
+        },
+        "security-manager" => {
+            "management-major-version" => 3,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:security-manager:1.0"]
+        },
+        "transactions" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:transactions:1.0",
+                "urn:jboss:domain:transactions:1.1",
+                "urn:jboss:domain:transactions:1.2",
+                "urn:jboss:domain:transactions:1.3",
+                "urn:jboss:domain:transactions:1.4",
+                "urn:jboss:domain:transactions:1.5",
+                "urn:jboss:domain:transactions:2.0",
+                "urn:jboss:domain:transactions:3.0",
+                "urn:jboss:domain:transactions:4.0",
+                "urn:jboss:domain:transactions:5.0",
+                "urn:jboss:domain:transactions:6.0"
+            ]
+        },
+        "undertow" => {
+            "management-major-version" => 13,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:undertow:3.1",
+                "urn:jboss:domain:undertow:4.0",
+                "urn:jboss:domain:undertow:5.0",
+                "urn:jboss:domain:undertow:6.0",
+                "urn:jboss:domain:undertow:7.0",
+                "urn:jboss:domain:undertow:8.0",
+                "urn:jboss:domain:undertow:9.0",
+                "urn:jboss:domain:undertow:10.0",
+                "urn:jboss:domain:undertow:11.0",
+                "urn:jboss:domain:undertow:12.0",
+                "urn:jboss:domain:undertow:13.0",
+                "urn:jboss:domain:undertow:14.0"
+            ]
+        },
+        "webservices" => {
+            "management-major-version" => 3,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:webservices:1.0",
+                "urn:jboss:domain:webservices:1.1",
+                "urn:jboss:domain:webservices:1.2",
+                "urn:jboss:domain:webservices:2.0"
+            ]
+        },
+        "weld" => {
+            "management-major-version" => 5,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:weld:1.0",
+                "urn:jboss:domain:weld:2.0",
+                "urn:jboss:domain:weld:3.0",
+                "urn:jboss:domain:weld:4.0",
+                "urn:jboss:domain:weld:5.0"
+            ]
+        }
+    }
+}

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wildfly.legacy.test</groupId>
         <artifactId>wildfly-legacy-test-parent</artifactId>
-        <version>7.0.1.Final-SNAPSHOT</version>
+        <version>8.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/versions/src/main/java/org/wildfly/legacy/version/LegacyVersions.java
+++ b/versions/src/main/java/org/wildfly/legacy/version/LegacyVersions.java
@@ -52,6 +52,8 @@ public class LegacyVersions {
     }
 
     public static void main(String[] args) {
+        // Once we replace WF29 placeholder with EAP 8.0.0, we replace this with 8.0.0
+        output("wf29");
         output("7.4.0");
     }
 

--- a/versions/src/main/resources/legacy-versions/standalone-model-versions-wf29.dmr
+++ b/versions/src/main/resources/legacy-versions/standalone-model-versions-wf29.dmr
@@ -1,0 +1,442 @@
+{
+    "core" => {
+        "standalone" => {
+            "management-major-version" => 22,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0
+        },
+        "product" => {
+            "product-name" => "WildFly Full",
+            "product-version" => "29.0.0.Final"
+        }
+    },
+    "subsystem" => {
+        "batch-jberet" => {
+            "management-major-version" => 3,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:batch-jberet:1.0",
+                "urn:jboss:domain:batch-jberet:2.0",
+                "urn:jboss:domain:batch-jberet:3.0"
+            ]
+        },
+        "bean-validation" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:bean-validation:1.0"]
+        },
+        "core-management" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:core-management:1.0"]
+        },
+        "datasources" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:datasources:1.1",
+                "urn:jboss:domain:datasources:1.2",
+                "urn:jboss:domain:datasources:2.0",
+                "urn:jboss:domain:datasources:3.0",
+                "urn:jboss:domain:datasources:4.0",
+                "urn:jboss:domain:datasources:5.0",
+                "urn:jboss:domain:datasources:6.0",
+                "urn:jboss:domain:datasources:7.0"
+            ]
+        },
+        "deployment-scanner" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:deployment-scanner:1.0",
+                "urn:jboss:domain:deployment-scanner:1.1",
+                "urn:jboss:domain:deployment-scanner:2.0"
+            ]
+        },
+        "discovery" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:discovery:1.0"]
+        },
+        "distributable-ejb" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:distributable-ejb:1.0"]
+        },
+        "distributable-web" => {
+            "management-major-version" => 3,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:distributable-web:1.0",
+                "urn:jboss:domain:distributable-web:2.0",
+                "urn:jboss:domain:distributable-web:3.0"
+            ]
+        },
+        "ee" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:ee:1.0",
+                "urn:jboss:domain:ee:1.1",
+                "urn:jboss:domain:ee:1.2",
+                "urn:jboss:domain:ee:2.0",
+                "urn:jboss:domain:ee:3.0",
+                "urn:jboss:domain:ee:4.0",
+                "urn:jboss:domain:ee:5.0",
+                "urn:jboss:domain:ee:6.0"
+            ]
+        },
+        "ee-security" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:ee-security:1.0"]
+        },
+        "ejb3" => {
+            "management-major-version" => 10,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:ejb3:1.0",
+                "urn:jboss:domain:ejb3:1.1",
+                "urn:jboss:domain:ejb3:1.2",
+                "urn:jboss:domain:ejb3:1.3",
+                "urn:jboss:domain:ejb3:1.4",
+                "urn:jboss:domain:ejb3:1.5",
+                "urn:jboss:domain:ejb3:2.0",
+                "urn:jboss:domain:ejb3:3.0",
+                "urn:jboss:domain:ejb3:4.0",
+                "urn:jboss:domain:ejb3:5.0",
+                "urn:jboss:domain:ejb3:6.0",
+                "urn:jboss:domain:ejb3:7.0",
+                "urn:jboss:domain:ejb3:8.0",
+                "urn:jboss:domain:ejb3:9.0",
+                "urn:jboss:domain:ejb3:10.0"
+            ]
+        },
+        "elytron" => {
+            "management-major-version" => 18,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:wildfly:elytron:1.0",
+                "urn:wildfly:elytron:1.1",
+                "urn:wildfly:elytron:1.2",
+                "urn:wildfly:elytron:2.0",
+                "urn:wildfly:elytron:3.0",
+                "urn:wildfly:elytron:4.0",
+                "urn:wildfly:elytron:5.0",
+                "urn:wildfly:elytron:6.0",
+                "urn:wildfly:elytron:7.0",
+                "urn:wildfly:elytron:8.0",
+                "urn:wildfly:elytron:9.0",
+                "urn:wildfly:elytron:10.0",
+                "urn:wildfly:elytron:11.0",
+                "urn:wildfly:elytron:12.0",
+                "urn:wildfly:elytron:13.0",
+                "urn:wildfly:elytron:14.0",
+                "urn:wildfly:elytron:15.0",
+                "urn:wildfly:elytron:15.1",
+                "urn:wildfly:elytron:16.0",
+                "urn:wildfly:elytron:17.0",
+                "urn:wildfly:elytron:18.0"
+            ]
+        },
+        "elytron-oidc-client" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:wildfly:elytron-oidc-client:1.0",
+                "urn:wildfly:elytron-oidc-client:2.0"
+            ]
+        },
+        "health" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:wildfly:health:1.0"]
+        },
+        "infinispan" => {
+            "management-major-version" => 17,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:infinispan:1.5",
+                "urn:jboss:domain:infinispan:2.0",
+                "urn:jboss:domain:infinispan:3.0",
+                "urn:jboss:domain:infinispan:4.0",
+                "urn:jboss:domain:infinispan:5.0",
+                "urn:jboss:domain:infinispan:6.0",
+                "urn:jboss:domain:infinispan:7.0",
+                "urn:jboss:domain:infinispan:8.0",
+                "urn:jboss:domain:infinispan:9.0",
+                "urn:jboss:domain:infinispan:9.1",
+                "urn:jboss:domain:infinispan:10.0",
+                "urn:jboss:domain:infinispan:11.0",
+                "urn:jboss:domain:infinispan:12.0",
+                "urn:jboss:domain:infinispan:13.0",
+                "urn:jboss:domain:infinispan:14.0"
+            ]
+        },
+        "io" => {
+            "management-major-version" => 5,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:io:1.0",
+                "urn:jboss:domain:io:1.1",
+                "urn:jboss:domain:io:2.0",
+                "urn:jboss:domain:io:3.0"
+            ]
+        },
+        "jaxrs" => {
+            "management-major-version" => 4,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jaxrs:1.0",
+                "urn:jboss:domain:jaxrs:2.0",
+                "urn:jboss:domain:jaxrs:3.0"
+            ]
+        },
+        "jca" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jca:1.1",
+                "urn:jboss:domain:jca:2.0",
+                "urn:jboss:domain:jca:3.0",
+                "urn:jboss:domain:jca:4.0",
+                "urn:jboss:domain:jca:5.0",
+                "urn:jboss:domain:jca:6.0"
+            ]
+        },
+        "jdr" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:jdr:1.0"]
+        },
+        "jmx" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 2,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jmx:1.0",
+                "urn:jboss:domain:jmx:1.1",
+                "urn:jboss:domain:jmx:1.2",
+                "urn:jboss:domain:jmx:1.3"
+            ]
+        },
+        "jpa" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 2,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jpa:1.1",
+                "urn:jboss:domain:jpa:1.0"
+            ]
+        },
+        "jsf" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 1,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:jsf:1.0",
+                "urn:jboss:domain:jsf:1.1"
+            ]
+        },
+        "logging" => {
+            "management-major-version" => 9,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:logging:1.0",
+                "urn:jboss:domain:logging:1.1",
+                "urn:jboss:domain:logging:1.2",
+                "urn:jboss:domain:logging:1.3",
+                "urn:jboss:domain:logging:1.4",
+                "urn:jboss:domain:logging:1.5",
+                "urn:jboss:domain:logging:2.0",
+                "urn:jboss:domain:logging:3.0",
+                "urn:jboss:domain:logging:4.0",
+                "urn:jboss:domain:logging:5.0",
+                "urn:jboss:domain:logging:6.0",
+                "urn:jboss:domain:logging:7.0",
+                "urn:jboss:domain:logging:8.0"
+            ]
+        },
+        "mail" => {
+            "management-major-version" => 4,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:mail:1.0",
+                "urn:jboss:domain:mail:1.1",
+                "urn:jboss:domain:mail:1.2",
+                "urn:jboss:domain:mail:2.0",
+                "urn:jboss:domain:mail:3.0",
+                "urn:jboss:domain:mail:4.0"
+            ]
+        },
+        "metrics" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:wildfly:metrics:1.0"]
+        },
+        "microprofile-config-smallrye" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:wildfly:microprofile-config-smallrye:1.0",
+                "urn:wildfly:microprofile-config-smallrye:2.0"
+            ]
+        },
+        "microprofile-jwt-smallrye" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:wildfly:microprofile-jwt-smallrye:1.0"]
+        },
+        "naming" => {
+            "management-major-version" => 2,
+            "management-minor-version" => 1,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:naming:1.0",
+                "urn:jboss:domain:naming:1.1",
+                "urn:jboss:domain:naming:1.2",
+                "urn:jboss:domain:naming:1.3",
+                "urn:jboss:domain:naming:1.4",
+                "urn:jboss:domain:naming:2.0"
+            ]
+        },
+        "pojo" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:pojo:1.0"]
+        },
+        "remoting" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:remoting:1.0",
+                "urn:jboss:domain:remoting:1.1",
+                "urn:jboss:domain:remoting:1.2",
+                "urn:jboss:domain:remoting:2.0",
+                "urn:jboss:domain:remoting:3.0",
+                "urn:jboss:domain:remoting:4.0",
+                "urn:jboss:domain:remoting:5.0"
+            ]
+        },
+        "request-controller" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 1,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:request-controller:1.0"]
+        },
+        "resource-adapters" => {
+            "management-major-version" => 7,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:resource-adapters:1.0",
+                "urn:jboss:domain:resource-adapters:1.1",
+                "urn:jboss:domain:resource-adapters:2.0",
+                "urn:jboss:domain:resource-adapters:3.0",
+                "urn:jboss:domain:resource-adapters:4.0",
+                "urn:jboss:domain:resource-adapters:5.0",
+                "urn:jboss:domain:resource-adapters:6.0",
+                "urn:jboss:domain:resource-adapters:6.1",
+                "urn:jboss:domain:resource-adapters:7.0"
+            ]
+        },
+        "sar" => {
+            "management-major-version" => 1,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:sar:1.0"]
+        },
+        "security-manager" => {
+            "management-major-version" => 3,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => ["urn:jboss:domain:security-manager:1.0"]
+        },
+        "transactions" => {
+            "management-major-version" => 6,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:transactions:1.0",
+                "urn:jboss:domain:transactions:1.1",
+                "urn:jboss:domain:transactions:1.2",
+                "urn:jboss:domain:transactions:1.3",
+                "urn:jboss:domain:transactions:1.4",
+                "urn:jboss:domain:transactions:1.5",
+                "urn:jboss:domain:transactions:2.0",
+                "urn:jboss:domain:transactions:3.0",
+                "urn:jboss:domain:transactions:4.0",
+                "urn:jboss:domain:transactions:5.0",
+                "urn:jboss:domain:transactions:6.0"
+            ]
+        },
+        "undertow" => {
+            "management-major-version" => 13,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:undertow:3.1",
+                "urn:jboss:domain:undertow:4.0",
+                "urn:jboss:domain:undertow:5.0",
+                "urn:jboss:domain:undertow:6.0",
+                "urn:jboss:domain:undertow:7.0",
+                "urn:jboss:domain:undertow:8.0",
+                "urn:jboss:domain:undertow:9.0",
+                "urn:jboss:domain:undertow:10.0",
+                "urn:jboss:domain:undertow:11.0",
+                "urn:jboss:domain:undertow:12.0",
+                "urn:jboss:domain:undertow:13.0",
+                "urn:jboss:domain:undertow:14.0"
+            ]
+        },
+        "webservices" => {
+            "management-major-version" => 3,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:webservices:1.0",
+                "urn:jboss:domain:webservices:1.1",
+                "urn:jboss:domain:webservices:1.2",
+                "urn:jboss:domain:webservices:2.0"
+            ]
+        },
+        "weld" => {
+            "management-major-version" => 5,
+            "management-minor-version" => 0,
+            "management-micro-version" => 0,
+            "xml-namespaces" => [
+                "urn:jboss:domain:weld:1.0",
+                "urn:jboss:domain:weld:2.0",
+                "urn:jboss:domain:weld:3.0",
+                "urn:jboss:domain:weld:4.0",
+                "urn:jboss:domain:weld:5.0"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFCORE-6437

DMR files were built based on WildFly Core 21.1.0.Final and WildFly 29.0.0.Final. 

To build it is necessary to use a wildfly-core version that includes https://github.com/wildfly/wildfly-core/pull/5593. For testing purposes, I used a `22.0.0.Beta1-SNAPSHOT` built locally.

This PR also drops legacy controllers that are no longer supported for mixed domains and bumps the project version to 8.0.0.Final-SNAPSHOT, since 8.0.0.Final release is the expected version to be used by WF.

