### PR TITLE
Fix wildfly core artifact

### DIFF
--- a/core/29.0.0/pom.xml
+++ b/core/29.0.0/pom.xml
@@ -27,7 +27,7 @@
       <relativePath>../pom.xml</relativePath>
    </parent>
 
-   <artifactId>wildfly-legacy-core-29_0_0</artifactId>
+   <artifactId>wildfly-legacy-core-29.0.0</artifactId>
 
    <name>WildFly: Legacy Test 21.1.x Core Controller</name>
    <description>The legacy Test SPI 21.1.x core controller used by WildFly 29_0_0.Final</description>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <repository>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>


### PR DESCRIPTION
@kabir My yesterday's changes introduced a mistake on the wildfly-core group ID

This mistake prevents us to keep the same pattern for the artifacts specified in wildfly-core, see https://github.com/wildfly/wildfly-core/pull/5602

WildFly Core is trying to resolve `org.wildfly.legacy.test:wildfly-legacy-core-29.0.0:jar:8.0.0.Final` however, due to the mistake we are resolving here, wildfly-legacy-test creates `org.wildfly.legacy.test:wildfly-legacy-core-29_0_0:jar:8.0.0.Final` artifact, which is wrong.

I also changed the URL of the  jboss-public-repository-group from http to https

Could you take a look at this PR and release another wildfly-legacy-test version with this fix? That should fix this problem